### PR TITLE
Fix layout scroll issue

### DIFF
--- a/stalker_ui/src/app/layouts/default/default.component.html
+++ b/stalker_ui/src/app/layouts/default/default.component.html
@@ -1,12 +1,10 @@
-<div class="layout">
-  <app-header (toggleSideBarEvent)="this.toggleSideBar()"></app-header>
+<app-header (toggleSideBarEvent)="this.toggleSideBar()"></app-header>
 
-  <mat-drawer-container autosize>
-    <mat-drawer mode="side" disableClose="true" opened="true">
-      <app-sidebar [expanded]="sideBarOpen"></app-sidebar>
-    </mat-drawer>
-    <mat-drawer-content>
-      <router-outlet></router-outlet>
-    </mat-drawer-content>
-  </mat-drawer-container>
-</div>
+<mat-drawer-container autosize>
+  <mat-drawer mode="side" disableClose="true" opened="true">
+    <app-sidebar [expanded]="sideBarOpen"></app-sidebar>
+  </mat-drawer>
+  <mat-drawer-content>
+    <router-outlet></router-outlet>
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/stalker_ui/src/app/layouts/default/default.component.scss
+++ b/stalker_ui/src/app/layouts/default/default.component.scss
@@ -1,9 +1,5 @@
 :host {
   height: 100vh;
-}
-
-.layout {
-  height: 100%;
   display: grid;
   grid-template-rows: minmax(64px, 64px) auto;
 }


### PR DESCRIPTION
On avait un petit problème avec le layout. Le fix c'est de mettre `box-sizing: border-box` pour dire que le padding est inclus dans la taille du div, mais j'en ai profité pour utiliser cssgrid parce que c'est clean.

J'ai acessoirement enlevé le footer aussi.