### PR TITLE
Adding last seen to the core elements

### DIFF
--- a/flow_manager/src/modules/database/database.constants.ts
+++ b/flow_manager/src/modules/database/database.constants.ts
@@ -1,1 +1,10 @@
+import { SchemaOptions } from '@nestjs/mongoose';
+
 export const MONGO_DUPLICATE_ERROR = 11000;
+export const MONGO_TIMESTAMP_SCHEMA_CONFIG: SchemaOptions = {
+  timestamps: {
+    currentTime: () => Date.now(),
+    createdAt: true,
+    updatedAt: true,
+  },
+};

--- a/flow_manager/src/modules/database/reporting/domain/domain.model.ts
+++ b/flow_manager/src/modules/database/reporting/domain/domain.model.ts
@@ -1,10 +1,11 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { MONGO_TIMESTAMP_SCHEMA_CONFIG } from '../../database.constants';
 import { HostSummary } from '../host/host.summary';
 
 export type DomainDocument = Domain & Document;
 
-@Schema()
+@Schema(MONGO_TIMESTAMP_SCHEMA_CONFIG)
 export class Domain {
   @Prop({ unique: true, index: true })
   public name!: string;
@@ -27,6 +28,15 @@ export class Domain {
 
   @Prop()
   public notes?: string;
+
+  @Prop()
+  public updatedAt: number;
+
+  @Prop()
+  public createdAt: number;
+
+  @Prop()
+  public lastSeen: number;
 }
 
 export const DomainSchema = SchemaFactory.createForClass(Domain);

--- a/flow_manager/src/modules/database/reporting/domain/domain.service.ts
+++ b/flow_manager/src/modules/database/reporting/domain/domain.service.ts
@@ -46,7 +46,8 @@ export class DomainsService {
     // for each domain, create a mongo id
     const domainDocuments: DomainDocument[] = [];
     const companyIdObject = new Types.ObjectId(companyId);
-    domains.forEach((domain) => {
+
+    for (const domain of domains) {
       const model = new this.domainModel({
         _id: new Types.ObjectId(),
         name: domain,
@@ -55,11 +56,12 @@ export class DomainsService {
           domain,
         ),
         companyId: companyIdObject,
+        lastSeen: Date.now(),
       });
       domainDocuments.push(model);
-    });
+    }
 
-    let insertedDomains: any = [];
+    let insertedDomains: DomainDocument[] = [];
 
     // insertmany with ordered false to continue on fail and use the exception
     try {
@@ -74,9 +76,9 @@ export class DomainsService {
     }
 
     const newDomains: string[] = [];
-    insertedDomains.forEach((domain: DomainDocument) => {
+    for (const domain of insertedDomains) {
       newDomains.push(domain.name);
-    });
+    }
 
     const config = await this.configService.getConfig();
 
@@ -168,6 +170,7 @@ export class DomainsService {
     }
     if (domain.hosts) throw new HttpNotImplementedException(); // has to validate hosts and unlink
     if (domain.correlationKey) throw new HttpNotImplementedException(); // should not change correlation key
+    domain.lastSeen = Date.now();
 
     return await this.domainModel.updateOne({ _id: { $eq: id } }, domain);
   }

--- a/flow_manager/src/modules/database/reporting/host/host.model.ts
+++ b/flow_manager/src/modules/database/reporting/host/host.model.ts
@@ -1,10 +1,11 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { MONGO_TIMESTAMP_SCHEMA_CONFIG } from '../../database.constants';
 import { DomainSummary } from '../domain/domain.summary';
 
 export type HostDocument = Host & Document;
 
-@Schema()
+@Schema(MONGO_TIMESTAMP_SCHEMA_CONFIG)
 export class Host {
   @Prop({ index: true })
   public ip!: string;
@@ -30,6 +31,15 @@ export class Host {
 
   @Prop()
   public notes?: string;
+
+  @Prop()
+  public updatedAt: number;
+
+  @Prop()
+  public createdAt: number;
+
+  @Prop()
+  public lastSeen: number;
 }
 
 export const HostSchema = SchemaFactory.createForClass(Host);

--- a/flow_manager/src/modules/database/reporting/host/host.service.ts
+++ b/flow_manager/src/modules/database/reporting/host/host.service.ts
@@ -116,6 +116,7 @@ export class HostService {
               ),
             },
             $addToSet: { domains: ds, tags: { $each: existingTags } },
+            lastSeen: Date.now(),
           },
           { upsert: true, useFindAndModify: false },
         )
@@ -173,6 +174,7 @@ export class HostService {
         ip: ip,
         companyId: new Types.ObjectId(companyId),
         correlationKey: CorrelationKeyUtils.hostCorrelationKey(companyId, ip),
+        lastSeen: Date.now(),
       });
 
       hostDocuments.push(model);

--- a/flow_manager/src/modules/database/reporting/port/port.model.ts
+++ b/flow_manager/src/modules/database/reporting/port/port.model.ts
@@ -1,9 +1,10 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { MONGO_TIMESTAMP_SCHEMA_CONFIG } from '../../database.constants';
 
 export type PortDocument = Port & Document;
 
-@Schema()
+@Schema(MONGO_TIMESTAMP_SCHEMA_CONFIG)
 export class Port {
   @Prop({ index: true })
   public hostId?: Types.ObjectId;
@@ -31,6 +32,15 @@ export class Port {
    */
   @Prop({ enum: ['tcp', 'udp'] })
   public layer4Protocol!: string;
+
+  @Prop()
+  public updatedAt: number;
+
+  @Prop()
+  public createdAt: number;
+
+  @Prop()
+  public lastSeen: number;
 }
 
 export const PortSchema = SchemaFactory.createForClass(Port);

--- a/flow_manager/src/modules/database/reporting/port/port.service.ts
+++ b/flow_manager/src/modules/database/reporting/port/port.service.ts
@@ -114,9 +114,20 @@ export class PortService {
     port.hostId = new Types.ObjectId(validHostId);
     port.layer4Protocol = protocol;
     port.correlationKey = correlationKey;
+    port.lastSeen = Date.now();
     port.tags = [];
 
     let res = null;
+
+    // Does not need to be awaited.
+    // Updating the lastSeen timestamp as, when we see a port, we see its host
+    this.hostModel
+      .updateOne(
+        { _id: { $eq: new Types.ObjectId(validHostId) } },
+        { lastSeen: Date.now() },
+      )
+      .exec();
+
     try {
       res = await this.portsModel.create(port);
     } catch (err) {

--- a/stalker_ui/src/app/modules/domains/view-domain/view-domain.component.html
+++ b/stalker_ui/src/app/modules/domains/view-domain/view-domain.component.html
@@ -8,6 +8,12 @@
     </div>
 
     <div class="context">
+      <panel-section *ngIf="domain">
+        <panel-section-title i18n="Last seen|Last seen"> Last seen </panel-section-title>
+        <panel-section-subtitle [matTooltip]="domain.lastSeen | humanizeDate : 'precise'" matTooltipPosition="before">
+          {{ domain.lastSeen | timeAgo }}
+        </panel-section-subtitle>
+      </panel-section>
       <panel-section *ngIf="(tagsSelectItems$ | async) && mergedTags$ | async as domainTags">
         <panel-section-title i18n="Tags|The tags of an item"
           >Tags

--- a/stalker_ui/src/app/modules/domains/view-domain/view-domain.component.ts
+++ b/stalker_ui/src/app/modules/domains/view-domain/view-domain.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
@@ -38,6 +39,7 @@ import { FindingsModule } from '../../findings/findings.module';
     MatDividerModule,
     MatButtonModule,
     MatIconModule,
+    MatTooltipModule,
   ],
   selector: 'app-view-domain',
   templateUrl: './view-domain.component.html',

--- a/stalker_ui/src/app/modules/hosts/view-host/view-host.component.html
+++ b/stalker_ui/src/app/modules/hosts/view-host/view-host.component.html
@@ -7,6 +7,12 @@
     </div>
 
     <div class="context">
+      <panel-section *ngIf="host">
+        <panel-section-title i18n="Last seen|Last seen"> Last seen </panel-section-title>
+        <panel-section-subtitle [matTooltip]="host.lastSeen | humanizeDate : 'precise'" matTooltipPosition="before">
+          {{ host.lastSeen | timeAgo }}
+        </panel-section-subtitle>
+      </panel-section>
       <panel-section *ngIf="(tagsSelectItems$ | async) && mergedTags$ | async as hostTags">
         <panel-section-title i18n="Tags|The tags of an item"
           >Tags

--- a/stalker_ui/src/app/modules/hosts/view-host/view-host.component.ts
+++ b/stalker_ui/src/app/modules/hosts/view-host/view-host.component.ts
@@ -12,10 +12,11 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import { BehaviorSubject, combineLatest, map, merge, Observable, Subject, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, combineLatest, map, merge, switchMap, tap } from 'rxjs';
 import { CompaniesService } from 'src/app/api/companies/companies.service';
 import { HostsService } from 'src/app/api/hosts/hosts.service';
 import { TagsService } from 'src/app/api/tags/tags.service';
@@ -55,6 +56,7 @@ import { FindingsModule } from '../../findings/findings.module';
     RouterModule,
     PanelSectionModule,
     AppHeaderComponent,
+    MatTooltipModule,
   ],
   selector: 'app-view-host',
   templateUrl: './view-host.component.html',

--- a/stalker_ui/src/app/modules/hosts/view-port/view-port.component.html
+++ b/stalker_ui/src/app/modules/hosts/view-port/view-port.component.html
@@ -9,6 +9,13 @@
       <findings-list [correlationKey]="(port$ | async)?.correlationKey"></findings-list>
     </div>
     <div class="context">
+      <panel-section *ngIf="port$ | async as port">
+        <panel-section-title i18n="Last seen|Last seen">Last seen</panel-section-title>
+        <panel-section-subtitle [matTooltip]="port.lastSeen | humanizeDate : 'precise'" matTooltipPosition="before">
+          {{ port.lastSeen | timeAgo }}
+        </panel-section-subtitle>
+      </panel-section>
+
       <panel-section *ngIf="(tagsSelectItems$ | async) && mergedTags$ | async as portTags">
         <panel-section-title i18n="Tags|The tags of an item"
           >Tags

--- a/stalker_ui/src/app/modules/hosts/view-port/view-port.component.ts
+++ b/stalker_ui/src/app/modules/hosts/view-port/view-port.component.ts
@@ -12,10 +12,11 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import { BehaviorSubject, combineLatest, map, merge, Observable, shareReplay, Subject, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, combineLatest, map, merge, shareReplay, switchMap, tap } from 'rxjs';
 import { CompaniesService } from 'src/app/api/companies/companies.service';
 import { HostsService } from 'src/app/api/hosts/hosts.service';
 import { TagsService } from 'src/app/api/tags/tags.service';
@@ -55,6 +56,7 @@ import { FindingsModule } from '../../findings/findings.module';
     RouterModule,
     PanelSectionModule,
     AppHeaderComponent,
+    MatTooltipModule,
   ],
   selector: 'app-view-port',
   templateUrl: './view-port.component.html',

--- a/stalker_ui/src/app/shared/pipes/humanize-date.pipe.ts
+++ b/stalker_ui/src/app/shared/pipes/humanize-date.pipe.ts
@@ -1,0 +1,33 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'humanizeDate',
+  pure: true,
+})
+export class HumanizeDatePipe implements PipeTransform {
+  transform(milliseconds: number, precision: 'approximate' | 'precise' = 'approximate'): string {
+    if (!milliseconds) return '';
+    return precision === 'approximate' ? this.approximate(milliseconds) : this.precise(milliseconds);
+  }
+
+  private approximate(milliseconds: number) {
+    const date = new Date(milliseconds);
+    const m = date.getMonth();
+    const mm = m >= 10 ? m.toString() : '0' + m.toString();
+    const d = date.getDay();
+    const dd = d >= 10 ? d.toString() : '0' + d.toString();
+
+    return `${date.getFullYear()}-${mm}-${dd}`;
+  }
+
+  private precise(milliseconds: number) {
+    const date = new Date(milliseconds);
+    const h = date.getHours();
+    const hh = h >= 10 ? h.toString() : '0' + h.toString();
+    const m = date.getMinutes();
+    const mm = m >= 10 ? m.toString() : '0' + m.toString();
+    const s = date.getSeconds();
+    const ss = s >= 10 ? s.toString() : '0' + s.toString();
+    return `${this.approximate(milliseconds)} ${hh}:${mm}:${ss}`;
+  }
+}

--- a/stalker_ui/src/app/shared/pipes/time-ago.pipe.ts
+++ b/stalker_ui/src/app/shared/pipes/time-ago.pipe.ts
@@ -5,8 +5,10 @@ import { Pipe, PipeTransform } from '@angular/core';
   pure: true,
 })
 export class TimeAgoPipe implements PipeTransform {
-  transform(value: Date | undefined): string {
+  transform(value: Date | number | undefined): string {
     if (!value) return '';
+
+    if (typeof value === 'number') value = new Date(value);
 
     const seconds = Math.floor((+new Date() - +value) / 1000);
     if (seconds < 29)

--- a/stalker_ui/src/app/shared/shared.module.ts
+++ b/stalker_ui/src/app/shared/shared.module.ts
@@ -26,6 +26,7 @@ import { NgxFileDropModule } from 'ngx-file-drop';
 import { FooterComponent } from './components/footer/footer.component';
 import { HeaderComponent } from './components/header/header.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
+import { HumanizeDatePipe } from './pipes/humanize-date.pipe';
 import { HumanizePipe } from './pipes/humanize.pipe';
 import { MemoryUnitsPipe } from './pipes/memory-units.pipe';
 import { TimeAgoPipe } from './pipes/time-ago.pipe';
@@ -56,6 +57,7 @@ import { TextSelectMenuComponent } from './widget/text-select-menu/text-select-m
     PillTagComponent,
     TimeAgoPipe,
     HumanizePipe,
+    HumanizeDatePipe,
     MemoryUnitsPipe,
     TextSelectMenuComponent,
     TextMenuComponent,
@@ -102,6 +104,7 @@ import { TextSelectMenuComponent } from './widget/text-select-menu/text-select-m
     PillTagComponent,
     TimeAgoPipe,
     HumanizePipe,
+    HumanizeDatePipe,
     MemoryUnitsPipe,
     CodeEditorComponent,
     TextSelectMenuComponent,

--- a/stalker_ui/src/app/shared/types/domain/domain.interface.ts
+++ b/stalker_ui/src/app/shared/types/domain/domain.interface.ts
@@ -8,4 +8,7 @@ export interface Domain {
   tags: string[];
   companyId: string;
   correlationKey: string;
+  lastSeen: number;
+  createdAt: number;
+  updatedAt: number;
 }

--- a/stalker_ui/src/app/shared/types/host/host.interface.ts
+++ b/stalker_ui/src/app/shared/types/host/host.interface.ts
@@ -8,4 +8,7 @@ export interface Host {
   tags: string[];
   companyId: string;
   correlationKey: string;
+  lastSeen: number;
+  createdAt: number;
+  updatedAt: number;
 }

--- a/stalker_ui/src/app/shared/types/ports/port.interface.ts
+++ b/stalker_ui/src/app/shared/types/ports/port.interface.ts
@@ -8,4 +8,7 @@ export interface PortNumber {
 export interface Port extends PortNumber {
   companyId: string;
   tags?: string[];
+  lastSeen: number;
+  createdAt: number;
+  updatedAt: number;
 }


### PR DESCRIPTION
Adding `lastSeen`, `createdAt` and `updatedAt` to the core elements (domains, hosts and ports).

The last seen date is visible in the UI. The last seen is shown in the "time ago" format, and hovering reveals a tooltip telling the precise date.

![image](https://github.com/red-kite-solutions/stalker/assets/21041333/48bc834d-dad7-4283-af6f-c0fa414d9dbb)


Closes #121 