### PR TITLE
Fixing the Orchestrator's deployment issues

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -34,17 +34,23 @@ pipelines:
 
       create_deployments ui flow-manager orchestrator-service-account orchestrator cron-service --sequential
 
-      # Wait for last services before applying network policies
+      # Wait for services before applying network policies
       wait_pod --label-selector app.kubernetes.io/component=ui --timeout 300
       wait_pod --label-selector app.kubernetes.io/component=flow-manager --timeout 300
       wait_pod --label-selector app.kubernetes.io/component=orchestrator --timeout 300
-      wait_pod --label-selector app.kubernetes.io/component=cron-service --timeout 300
+
 
       create_deployments network-policies
       create_deployments resource-quotas
 
       # Start microservices + ui
-      start_dev orchestrator flow-manager ui cron-service
+      start_dev orchestrator flow-manager ui
+
+      create_deployments cron-service
+
+      wait_pod --label-selector app.kubernetes.io/component=cron-service --timeout 300
+
+      start_dev cron-service
 
   flow-manager-e2e:
     flags:

--- a/orchestrator/.dockerignore
+++ b/orchestrator/.dockerignore
@@ -1,0 +1,12 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.trx
+**/*.md
+**/*.ps1
+**/*.cmd
+**/*.sh


### PR DESCRIPTION
deployment improvements, fixing the long lasting orchestrator deployment, I hope for good, and helping with the error messages from the cron service.

Found the orchestrator solution here: https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1064

Which lead to here: https://stackoverflow.com/questions/61167032/error-netsdk1064-package-dnsclient-1-2-0-was-not-found 

Which lead to here: https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/.dockerignore 