### PR TITLE
171 - Harden the orchestrator's service account permissions

### DIFF
--- a/orchestrator/orchestrator-service-account.yml
+++ b/orchestrator/orchestrator-service-account.yml
@@ -5,15 +5,23 @@ metadata:
   namespace: stalker-jobs
 rules:
   - apiGroups:
-      - ""
       - "batch"
     resources:
-      - "*"
+      - "jobs"
     verbs:
-      - "*"
-
-# Actually needed
-# - batch/create/jobs
+      - "create"
+      - "delete"
+      - "deletecollection"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "pods/log"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "logs"
 
 ---
 kind: ServiceAccount


### PR DESCRIPTION
Closes #171 

This PR hardens the orchestrator's service account RBAC.

It can now create and delete jobs and read the pods to get the output.