### PR TITLE
WIP: Prod tweaks and dependency install

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -667,6 +667,7 @@ dev:
       inject: false
     ports:
       - port: "${STALKER_PORT}:443"
+        bindAddress: ${STALKER_BIND_ADDRESS}
     resources:
       limits:
         memory: 1Gi

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -578,6 +578,10 @@ dev:
       statefulset.kubernetes.io/pod-name: mongo-mongodb-0
     ports:
       - port: "27017"
+    resources:
+      limits:
+        memory: 2Gi
+        cpu: 1
 
   mongo-prod:
     labelSelector:
@@ -609,6 +613,10 @@ dev:
       enabled: true
     restartHelper:
       inject: false
+    resources:
+      limits:
+        memory: 2Gi
+        cpu: 1
 
   flow-manager-e2e:
     labelSelector:

--- a/docs/docs/advanced/architecture.md
+++ b/docs/docs/advanced/architecture.md
@@ -27,7 +27,7 @@ The following table goes over the main aspects of the graph :
 | Nginx (UI)        | 80, 443          | 53 (DNS), 3000 (FM)                                                         |
 | Flow Manager (FM) | 3000             | 53 (DNS), 9092 (Kafka), 27017 (Mongo)                                       |
 | Cron Service      | Deny All         | 53 (DNS), 3000 (FM), 27017 (Mongo)                                          |
-| Mongo             | 27017            | Deny All                                                                    |
+| Mongo             | 27017            | 27017 (Mongo)                                                               |
 | Kafka             | 9092, 9093, 9094 | 53 (DNS), 9092 (Kafka), 9093 (Kafka), 9094 (Kafka)                          |
 | Orchestrator      | Deny All         | 53 (DNS), 443 (K8s API), 9092 (Kafka)                                       |
 | Jobs              | Deny All         | 0.0.0.0/0 except 169.254.169.254, 172.16.0.0/12, 192.168.0.0/16, 10.0.0.0/8 |

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -34,6 +34,14 @@ You can use Stalker with your own production ready deployment. Simply follow the
 - keytool
 - openssl
 
+If you use a `Ubuntu Server`, you can use the provided initialization script. Simply run:
+
+```bash
+curl https://raw.githubusercontent.com/red-kite-solutions/stalker/main/init_ubuntu.sh | bash
+```
+
+If you ran the script successfully, you can log out and log back in, and then directly go to [start stalker](#5-start-stalker).
+
 ### 2. Clone the repository
 
 ```bash
@@ -62,7 +70,7 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
 
-### 5. Start Stalker:
+### 5. Start Stalker
 
 > When initializing for the first time, Stalker will prompt you several times for your root CA key's password.
 
@@ -97,7 +105,7 @@ Any time you want to start Stalker again in the future, simply run the start up 
 ./stalker
 ```
 
-If something went wrong during the install,
+> If something went wrong during the install, or you simply want to rerun the setup, you can run Stalker with the `--force-setup` flag.
 
 ## Core concepts
 

--- a/init_ubuntu.sh
+++ b/init_ubuntu.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash 
+
+STALKER_REPO="https://github.com/red-kite-solutions/stalker"
+DOCKER_USER=$USER
+DOCKER_USER_HOME=${HOME}
+
+sudo apt update >/dev/null
+sudo apt install -y ca-certificates curl gnupg npm git openssl default-jdk >/dev/null
+echo "Installed necessities"
+
+# Setup keyring
+sudo install -m 0755 -d /etc/apt/keyrings >/dev/null
+
+# Add docker gpg key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg >/dev/null
+sudo chmod a+r /etc/apt/keyrings/docker.gpg >/dev/null
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install docker
+sudo apt update >/dev/null
+sudo apt -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin >/dev/null
+echo "Installed docker"
+
+# Install minikube & kubectl
+curl -sLO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 >/dev/null
+curl -sLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install kubectl /usr/local/bin/kubectl
+sudo install minikube-linux-amd64 /usr/local/bin/minikube
+rm minikube-linux-amd64
+rm kubectl
+echo "Installed minikube and kubectl"
+
+# Setup npm for global install
+mkdir "${DOCKER_USER_HOME}/.npm-packages"
+echo 'NPM_PACKAGES="${HOME}/.npm-packages"' >> ${DOCKER_USER_HOME}/.bashrc
+NPM_PACKAGES="${DOCKER_USER_HOME}/.npm-packages"
+echo 'prefix=${HOME}/.npm-packages' >> ${DOCKER_USER_HOME}/.npmrc
+echo 'NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"' >> ${DOCKER_USER_HOME}/.bashrc
+NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
+echo 'PATH="$NPM_PACKAGES/bin:$PATH"' >> ${DOCKER_USER_HOME}/.bashrc
+PATH="$NPM_PACKAGES/bin:$PATH"
+
+# Install devspace
+npm install -g devspace > /dev/null
+echo "Installed devspace"
+
+# Cloning Stalker repository
+git clone ${STALKER_REPO} >/dev/null
+
+# Adding the current user to the docker group
+sudo groupadd docker
+sudo usermod -a -G docker $DOCKER_USER
+
+chmod +x ./stalker/stalker
+echo "Installation successfull. Log off and log back in for all the changes to take effect."

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,11 @@
 STALKER_HOSTNAME=stalker.lan
 STALKER_PORT=8443
 
+# Bind address indicates from where Stalker will accept connections
+# 0.0.0.0 means from everywhere
+# 127.0.0.1 means only from localhost
+STALKER_BIND_ADDRESS="0.0.0.0"
+
 # Max database size and replication. Having 3 replicas with 32Gi would mean that 
 # (32 * 3) Gi of space on disk is needed
 MONGODB_MAX_SIZE="32Gi"
@@ -87,6 +92,7 @@ vars:
   DOCKERFILE_NAME: Dockerfile
   FM_URL: "https://flow-manager:3000"
   MONGODB_MAX_SIZE: $MONGODB_MAX_SIZE
+  STALKER_BIND_ADDRESS: $STALKER_BIND_ADDRESS
 EOF
 
 cat > "root_ca.cnf" << EOF

--- a/stalker
+++ b/stalker
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Minikube resources
+MINIKUBE_RAM=16384
+MINIKUBE_CPU=8
 
 if [[ $* == *--help* || $* == *-h* ]]; then
   echo 'Stalker setup tool'
@@ -34,6 +37,6 @@ if [ ! -f "devspace.prod.yaml" ]; then
 fi
 
 if ! (minikube status &>/dev/null); then
-  minikube start --driver=docker --memory=16384 --cpus=8
+  minikube start --driver=docker --memory=$MINIKUBE_RAM --cpus=$MINIKUBE_CPU
 fi
 devspace --var="STALKER_ENVIRONMENT=prod" run-pipeline prod -n stalker


### PR DESCRIPTION
In this PR, I will tweak some resources and make basic changes related to a basic prod deployment in minikube. As I deploy it myself and scan a vast environment, I will apply changes here.

For now, this PR adds:

- A script to install dependencies if you run `Ubuntu Server`. It most likely works on any Debian flavor that uses the `apt` package manager
- A network tweak to allow connections from anywhere, not just localhost, in production
- The ability to modify the bind address in the `setup.sh` script

> This PR is a work in progress and is not ready for review.