### PR TITLE
Cleanup through generic cron reminders

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -420,6 +420,13 @@ deployments:
                     collection: "cronsubscriptions"
                   },
                   actions: ["find"]
+                },
+                {
+                  resource: {
+                    db: "stalker",
+                    collection: "alarms"
+                  },
+                  actions: ["find"]
                 }
               ],
               roles: []

--- a/packages/backend/cron/service/src/modules/connectors/alarm.connector.ts
+++ b/packages/backend/cron/service/src/modules/connectors/alarm.connector.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import fetch, { Headers } from 'node-fetch';
+
+@Injectable()
+export class AlarmConnector {
+  public async notify(path: string) {
+    const headers = new Headers();
+    path = path.startsWith('/') ? path : '/' + path;
+    headers.append('x-stalker-cron', process.env.STALKER_CRON_API_TOKEN);
+    await fetch(`${process.env.JM_URL}${path}`, {
+      method: 'POST',
+      headers: headers,
+    });
+  }
+}

--- a/packages/backend/cron/service/src/modules/connectors/connector.module.ts
+++ b/packages/backend/cron/service/src/modules/connectors/connector.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AlarmConnector } from './alarm.connector';
 import { CronConnector } from './cron.connector';
 
 @Module({
   imports: [],
   controllers: [],
-  providers: [CronConnector],
-  exports: [CronConnector],
+  providers: [CronConnector, AlarmConnector],
+  exports: [CronConnector, AlarmConnector],
 })
 export class ConnectorModule {}

--- a/packages/backend/cron/service/src/modules/database/alarm/alarm.controller.ts
+++ b/packages/backend/cron/service/src/modules/database/alarm/alarm.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, UseGuards } from '@nestjs/common';
+import { DevFeatureGuard } from '../../../guards/dev-feature.guard';
+import { AlarmService } from './alarm.service';
+
+@UseGuards(DevFeatureGuard)
+@Controller('alarms')
+export class AlarmController {
+  constructor(private alarmService: AlarmService) {}
+}

--- a/packages/backend/cron/service/src/modules/database/alarm/alarm.model.ts
+++ b/packages/backend/cron/service/src/modules/database/alarm/alarm.model.ts
@@ -1,0 +1,21 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type AlarmDocument = Alarm & Document;
+
+@Schema()
+export class Alarm {
+  @Prop({ unique: true })
+  public name: string;
+
+  @Prop()
+  public isEnabled: boolean;
+
+  @Prop()
+  public path: string;
+
+  @Prop()
+  public cronExpression: string;
+}
+
+export const AlarmSchema = SchemaFactory.createForClass(Alarm);

--- a/packages/backend/cron/service/src/modules/database/alarm/alarm.module.ts
+++ b/packages/backend/cron/service/src/modules/database/alarm/alarm.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ConnectorModule } from '../../connectors/connector.module';
+import { AlarmController } from './alarm.controller';
+import { AlarmSchema } from './alarm.model';
+import { AlarmService } from './alarm.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      {
+        name: 'alarms',
+        schema: AlarmSchema,
+      },
+    ]),
+    ConnectorModule,
+  ],
+  providers: [AlarmService],
+  controllers: [AlarmController],
+  exports: [AlarmService],
+})
+export class AlarmModule {}

--- a/packages/backend/cron/service/src/modules/database/alarm/alarm.service.ts
+++ b/packages/backend/cron/service/src/modules/database/alarm/alarm.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { E_TIMEOUT, Mutex, withTimeout } from 'async-mutex';
+import { Model } from 'mongoose';
+import { cronShouldRun } from '../../../utils/cron.utils';
+import { AlarmConnector } from '../../connectors/alarm.connector';
+import { Alarm, AlarmDocument } from './alarm.model';
+
+@Injectable()
+export class AlarmService {
+  /**
+   * This class is a singleton and should not be instanciated manually
+   */
+  constructor(
+    @InjectModel('alarms')
+    private readonly alarmModel: Model<Alarm>,
+    private readonly alarmConnector: AlarmConnector,
+  ) {}
+
+  private logger = new Logger(AlarmService.name);
+  private alarmCache: AlarmDocument[] = [];
+  private cacheMutex = withTimeout(
+    new Mutex(),
+    10000,
+    new Error('Timed out while waiting for mutex.'),
+  );
+  private cacheUpdateRunning = false;
+  private ringAlarmsRunning = false;
+  private lastJobLaunchStart = Date.now();
+
+  public async getAlarms() {
+    return await this.alarmModel
+      .find({})
+      .select('_id name cronExpression isEnabled path');
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE, {
+    name: 'Update alarm cache',
+  })
+  public async updateAlarmCache() {
+    if (this.cacheUpdateRunning) {
+      this.logger.warn(
+        'Cache update is already running, cancelling this update',
+      );
+      return;
+    }
+    this.cacheUpdateRunning = true;
+    try {
+      await this.cacheMutex.runExclusive(async () => {
+        this.alarmCache = await this.getAlarms();
+      });
+    } catch (e) {
+      if (e === E_TIMEOUT) {
+        this.logger.error('updateAlarmCache: Timeout while waiting for mutex');
+      }
+      this.logger.error(e);
+    } finally {
+      this.cacheUpdateRunning = false;
+    }
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS, {
+    name: 'Notify alarms',
+  })
+  public async ringAlarms() {
+    if (this.ringAlarmsRunning) {
+      this.logger.warn('ringAlarms is already running, cancelling this run');
+      return;
+    }
+    this.ringAlarmsRunning = true;
+
+    try {
+      await this.cacheMutex.runExclusive(async () => {
+        const now = Date.now();
+        for (const alarm of this.alarmCache) {
+          try {
+            this.ringAlarm(alarm, now);
+          } catch (e) {
+            this.logger.error(e);
+            this.logger.error(
+              `Failed to run alarm with id '${alarm._id}', cron expression '${alarm.cronExpression}'`,
+            );
+          }
+        }
+
+        this.lastJobLaunchStart = now;
+      });
+    } catch (e) {
+      if (e === E_TIMEOUT) {
+        this.logger.error('notifyCronJobs: Timeout while waiting for mutex');
+      }
+      this.logger.error(e);
+    } finally {
+      this.ringAlarmsRunning = false;
+    }
+  }
+
+  private ringAlarm(alarm: AlarmDocument, now: number) {
+    if (!alarm) {
+      this.logger.error('Failed to ring the alarm as it is falsy');
+      return;
+    }
+
+    const { path, cronExpression, isEnabled, name } = alarm;
+
+    const shouldRun = cronShouldRun(
+      cronExpression,
+      this.lastJobLaunchStart,
+      now,
+    );
+    if (!shouldRun) {
+      return;
+    }
+
+    if (!isEnabled) {
+      this.logger.debug(
+        `Skipping execution for "${name}" because it is disabled.`,
+      );
+      return;
+    }
+
+    // Fire and forget
+    this.alarmConnector.notify(path).catch((reason) => {
+      this.logger.error(reason);
+      this.logger.error(
+        'Error while notifying the jobs manager. Continuing...',
+      );
+    });
+  }
+}

--- a/packages/backend/cron/service/src/modules/database/database.module.ts
+++ b/packages/backend/cron/service/src/modules/database/database.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import { AlarmModule } from './alarm/alarm.module';
 import { CronSubscriptionsModule } from './subscriptions/cron-subscriptions/cron-subscriptions.module';
 
 @Module({
@@ -17,6 +18,7 @@ import { CronSubscriptionsModule } from './subscriptions/cron-subscriptions/cron
       tlsCertificateKeyFilePassword: process.env.CRON_MONGO_KEY_PASSWORD,
     }),
     CronSubscriptionsModule,
+    AlarmModule,
   ],
   exports: [],
 })

--- a/packages/backend/cron/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.controller.ts
+++ b/packages/backend/cron/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Logger, Put, UseGuards } from '@nestjs/common';
 import { DevFeatureGuard } from '../../../../guards/dev-feature.guard';
 import { CronSubscriptionsService } from './cron-subscriptions.service';
 
+@UseGuards(DevFeatureGuard)
 @Controller('cron-subscriptions')
 export class CronSubscriptionsController {
   private logger = new Logger(CronSubscriptionsController.name);
@@ -10,13 +11,11 @@ export class CronSubscriptionsController {
     private readonly cronSubscriptionsService: CronSubscriptionsService,
   ) {}
 
-  @UseGuards(DevFeatureGuard)
   @Get()
   async getCronSubscriptions(): Promise<any> {
     return await this.cronSubscriptionsService.getCronSubscriptions();
   }
 
-  @UseGuards(DevFeatureGuard)
   @Put('update-cache')
   async updateCache(): Promise<any> {
     return await this.cronSubscriptionsService.updateSubscriptionCache();

--- a/packages/backend/cron/service/src/utils/cron.utils.spec.ts
+++ b/packages/backend/cron/service/src/utils/cron.utils.spec.ts
@@ -1,6 +1,6 @@
-import { CronSubscriptionsService } from './cron-subscriptions.service';
+import { cronShouldRun } from './cron.utils';
 
-describe('CronSubscriptionsService', () => {
+describe('CronUtils', () => {
   // Here are timestamp (ms) examples of a check every 10 seconds
   // for a cron that should start every 30 seconds
   //          */30 * * * * ?
@@ -22,11 +22,7 @@ describe('CronSubscriptionsService', () => {
     const startTime = 1701305999999;
 
     //Act
-    const result = CronSubscriptionsService.cronShouldRun(
-      cronExpression,
-      lastRunTime,
-      startTime,
-    );
+    const result = cronShouldRun(cronExpression, lastRunTime, startTime);
 
     //Assert
     expect(result).toStrictEqual(false);
@@ -39,11 +35,7 @@ describe('CronSubscriptionsService', () => {
     let startTime = 1701306000000;
 
     //Act
-    let result = CronSubscriptionsService.cronShouldRun(
-      cronExpression,
-      lastRunTime,
-      startTime,
-    );
+    let result = cronShouldRun(cronExpression, lastRunTime, startTime);
 
     //Assert
     expect(result).toStrictEqual(false);
@@ -53,11 +45,7 @@ describe('CronSubscriptionsService', () => {
     startTime = 1701306010000;
 
     //Act
-    result = CronSubscriptionsService.cronShouldRun(
-      cronExpression,
-      lastRunTime,
-      startTime,
-    );
+    result = cronShouldRun(cronExpression, lastRunTime, startTime);
 
     //Assert
     expect(result).toStrictEqual(true);
@@ -70,11 +58,7 @@ describe('CronSubscriptionsService', () => {
     const startTime = 1701306000001;
 
     //Act
-    const result = CronSubscriptionsService.cronShouldRun(
-      cronExpression,
-      lastRunTime,
-      startTime,
-    );
+    const result = cronShouldRun(cronExpression, lastRunTime, startTime);
 
     //Assert
     expect(result).toStrictEqual(true);

--- a/packages/backend/cron/service/src/utils/cron.utils.ts
+++ b/packages/backend/cron/service/src/utils/cron.utils.ts
@@ -1,0 +1,13 @@
+import { parseExpression } from 'cron-parser';
+
+export function cronShouldRun(
+  cronExpression: string,
+  lastRunStart: number,
+  currentRunStart: number,
+): boolean {
+  const parsedCron = parseExpression(cronExpression, {
+    currentDate: new Date(currentRunStart),
+  });
+  const prevCronTime = parsedCron.prev().getTime();
+  return lastRunStart <= prevCronTime && prevCronTime < currentRunStart;
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.default.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.default.ts
@@ -1,3 +1,4 @@
+import { Config } from './config.model';
 import { JobPodConfiguration } from './job-pod-config/job-pod-config.model';
 
 const baseMemory = 1024;
@@ -38,4 +39,10 @@ export const DEFAULT_JOB_POD_FALLBACK_CONFIG: JobPodConfiguration = {
   name: 'Stalker Default Fallback Job Pod Config',
   memoryKbytesLimit: baseMemory * 100,
   milliCpuLimit: 100,
+};
+
+export const DEFAULT_GENERAL_CONFIG: Config = {
+  findingRetentionTimeSeconds: 60 * 60 * 24 * 365, // ~1 year
+  jobRunRetentionTimeSeconds: 60 * 60 * 24 * 14, // 14 days
+  subscriptionTriggerRetentionTimeSeconds: 60 * 60 * 24 * 365, // ~1 year
 };

--- a/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.model.ts
@@ -1,9 +1,18 @@
-import { Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
 export type ConfigDocument = Config & Document;
 
 @Schema({ capped: { max: 1 } })
-export class Config {}
+export class Config {
+  @Prop()
+  jobRunRetentionTimeSeconds: number;
+
+  @Prop()
+  findingRetentionTimeSeconds: number;
+
+  @Prop()
+  subscriptionTriggerRetentionTimeSeconds: number;
+}
 
 export const ConfigSchema = SchemaFactory.createForClass(Config);

--- a/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.provider.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.provider.ts
@@ -1,6 +1,10 @@
 import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { DEFAULT_JOB_POD_CONFIG } from './config.default';
+import {
+  DEFAULT_GENERAL_CONFIG,
+  DEFAULT_JOB_POD_CONFIG,
+} from './config.default';
+import { Config } from './config.model';
 import { JobPodConfiguration } from './job-pod-config/job-pod-config.model';
 
 export const DATABASE_INIT = 'DATABASE_INIT';
@@ -8,8 +12,11 @@ export const DATABASE_INIT = 'DATABASE_INIT';
 export const databaseConfigInitProvider = [
   {
     provide: DATABASE_INIT,
-    inject: [getModelToken('jobPodConfig')],
-    useFactory: async (jobPodConfigModel: Model<JobPodConfiguration>) => {
+    inject: [getModelToken('jobPodConfig'), getModelToken('config')],
+    useFactory: async (
+      jobPodConfigModel: Model<JobPodConfiguration>,
+      config: Model<Config>,
+    ) => {
       const jpConf = await jobPodConfigModel.findOne();
       if (!jpConf) {
         const jobPodConfigs: JobPodConfiguration[] = JSON.parse(
@@ -19,6 +26,12 @@ export const databaseConfigInitProvider = [
           await jobPodConfigModel.create(c);
         }
       }
+
+      const currentConfig = await config.findOne();
+      if (!currentConfig) {
+        await config.create(DEFAULT_GENERAL_CONFIG);
+      }
+
       return DATABASE_INIT;
     },
   },

--- a/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/admin/config/config.service.ts
@@ -39,4 +39,8 @@ export class ConfigService {
       _id: new Types.ObjectId(id),
     });
   }
+
+  public async getConfig(): Promise<Config> {
+    return await this.configModel.findOne();
+  }
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm-model.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm-model.module.ts
@@ -1,0 +1,9 @@
+import { MongooseModule } from '@nestjs/mongoose';
+import { AlarmSchema } from './alarm.model';
+
+export const AlarmModelModule = MongooseModule.forFeature([
+  {
+    name: 'alarms',
+    schema: AlarmSchema,
+  },
+]);

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.constants.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.constants.ts
@@ -1,0 +1,16 @@
+import { Alarm } from './alarm.model';
+
+export const DEFAULT_ALARMS: Alarm[] = [
+  {
+    name: 'Clear job runs',
+    cronExpression: '0 0 * * *',
+    isEnabled: true,
+    path: '/jobs/cleanup',
+  },
+  {
+    name: 'Clear findings',
+    cronExpression: '0 0 * * *',
+    isEnabled: true,
+    path: '/findings/cleanup',
+  },
+];

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, UseGuards } from '@nestjs/common';
+import { Role } from '../../auth/constants';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/role.guard';
+import { AlarmService } from './alarm.service';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+@Controller('alarms')
+export class AlarmController {
+  constructor(private alarmService: AlarmService) {}
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.e2e-spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.e2e-spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestingData, cleanup, initTesting } from '../../../test/e2e.utils';
+import { AppModule } from '../../app.module';
+
+describe('Alarm Controller (e2e)', () => {
+  let app: INestApplication;
+  let testData: TestingData;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+    testData = await initTesting(app);
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await app.close();
+  });
+
+  it('Should be true (VERB /alarm/)', async () => {
+    // arrange & act
+    // assert
+
+    expect(true).toBe(true);
+  });
+
+  // ####################################
+  // ########## Authorizations ##########
+  // ####################################
+});

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.model.ts
@@ -1,0 +1,21 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type AlarmDocument = Alarm & Document;
+
+@Schema()
+export class Alarm {
+  @Prop({ unique: true })
+  public name: string;
+
+  @Prop()
+  public isEnabled: boolean;
+
+  @Prop()
+  public path: string;
+
+  @Prop()
+  public cronExpression: string;
+}
+
+export const AlarmSchema = SchemaFactory.createForClass(Alarm);

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatalayerModule } from '../datalayer.module';
+import { AlarmController } from './alarm.controller';
+import { alarmInitProvider } from './alarm.provider';
+import { AlarmService } from './alarm.service';
+
+@Module({
+  imports: [DatalayerModule],
+  providers: [AlarmService, ...alarmInitProvider],
+  controllers: [AlarmController],
+  exports: [AlarmService, ...alarmInitProvider],
+})
+export class AlarmModule {}

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.provider.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.provider.ts
@@ -1,0 +1,21 @@
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { DEFAULT_ALARMS } from './alarm.constants';
+import { Alarm } from './alarm.model';
+
+export const ALARM_INIT = 'ALARM_INIT';
+
+export const alarmInitProvider = [
+  {
+    provide: ALARM_INIT,
+    inject: [getModelToken('alarms')],
+    useFactory: async (alarmModel: Model<Alarm>) => {
+      const anyAlarm = await alarmModel.findOne({});
+      if (anyAlarm) return;
+
+      for (let alarm of DEFAULT_ALARMS) {
+        await alarmModel.create(alarm);
+      }
+    },
+  },
+];

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.service.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.service.spec.ts
@@ -1,0 +1,35 @@
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Model } from 'mongoose';
+import { AppModule } from '../../app.module';
+import { Alarm } from './alarm.model';
+import { AlarmService } from './alarm.service';
+
+describe('AlarmService', () => {
+  let alarmService: AlarmService;
+  let alarmModel: Model<Alarm>;
+  let moduleFixture: TestingModule;
+
+  beforeAll(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    alarmService = moduleFixture.get(AlarmService);
+    alarmModel = moduleFixture.get<Model<Alarm>>(getModelToken('alarms'));
+  });
+
+  afterAll(async () => {
+    await moduleFixture.close();
+  });
+
+  beforeEach(async () => {
+    const alarms = await alarmService.getAll();
+    for (const s of alarms) {
+      await alarmService.delete(s._id.toString());
+    }
+  });
+
+  it('Should be true', () => {
+    expect(true).toStrictEqual(true);
+  });
+});

--- a/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/alarm/alarm.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Alarm, AlarmDocument } from './alarm.model';
+
+@Injectable()
+export class AlarmService {
+  constructor(
+    @InjectModel('alarms')
+    private readonly alarmModel: Model<Alarm>,
+  ) {}
+
+  public async getAll(): Promise<AlarmDocument[]> {
+    return await this.alarmModel.find({});
+  }
+
+  public async get(id: string): Promise<AlarmDocument | null> {
+    return await this.alarmModel.findById(id);
+  }
+
+  public async create(
+    name: string,
+    cronExpression: string,
+    enabled: boolean,
+    path: string,
+  ): Promise<AlarmDocument> {
+    return await this.alarmModel.create({
+      name: name,
+      cronExpression: cronExpression,
+      enabled: enabled,
+      path: path,
+    });
+  }
+
+  public async delete(id: string) {
+    return this.alarmModel.deleteOne({ _id: { $eq: new Types.ObjectId(id) } });
+  }
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/database.constants.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/database.constants.ts
@@ -1,9 +1,11 @@
 import { SchemaOptions } from '@nestjs/mongoose';
 
+export const MONGO_TIMESTAMP_FUNCTION = () => Date.now();
+
 export const MONGO_DUPLICATE_ERROR = 11000;
 export const MONGO_TIMESTAMP_SCHEMA_CONFIG: SchemaOptions = {
   timestamps: {
-    currentTime: () => Date.now(),
+    currentTime: MONGO_TIMESTAMP_FUNCTION,
     createdAt: true,
     updatedAt: true,
   },

--- a/packages/backend/jobs-manager/service/src/modules/database/database.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/database.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule, MongooseModuleOptions } from '@nestjs/mongoose';
 import { ConfigModule } from './admin/config/config.module';
+import { AlarmModule } from './alarm/alarm.module';
 import { CustomJobsModule } from './custom-jobs/custom-jobs.module';
 import { JobsModule } from './jobs/jobs.module';
 import { ProjectModule } from './reporting/project.module';
@@ -46,6 +47,7 @@ const mongooseModuleOptions: MongooseModuleOptions =
     CronSubscriptionsModule,
     CustomJobsModule,
     SecretsModule,
+    AlarmModule,
   ],
   exports: [JobsModule],
   providers: [],

--- a/packages/backend/jobs-manager/service/src/modules/database/datalayer.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/datalayer.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModelModule } from './admin/config/config-model.module';
 import { databaseConfigInitProvider } from './admin/config/config.provider';
 import { JobPodConfigModelModule } from './admin/config/job-pod-config/job-pod-config-model.module';
+import { AlarmModelModule } from './alarm/alarm-model.module';
 import { JobModelModule } from './jobs/job-model.module';
 import { DomainModelModule } from './reporting/domain/domain-model.module';
 import { FindingModelModule } from './reporting/findings/findings-model.module';
@@ -25,6 +26,7 @@ import { TagModelModule } from './tags/tag-model.module';
     JobPodConfigModelModule,
     CronSubscriptionModelModule,
     SecretsModelModule,
+    AlarmModelModule,
   ],
   providers: [...databaseConfigInitProvider],
   exports: [
@@ -39,6 +41,7 @@ import { TagModelModule } from './tags/tag-model.module';
     JobPodConfigModelModule,
     CronSubscriptionModelModule,
     SecretsModelModule,
+    AlarmModelModule,
   ],
 })
 export class DatalayerModule {}

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
@@ -20,6 +20,7 @@ import { Page } from '../../../types/page.type';
 import { ProjectUnassigned } from '../../../validators/is-project-id.validator';
 import { Role } from '../../auth/constants';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { CronApiTokenGuard } from '../../auth/guards/cron-api-token.guard';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/role.guard';
 import { ConfigService } from '../admin/config/config.service';
@@ -133,6 +134,12 @@ export class JobsController {
   @Delete()
   async deleteAllJobs() {
     return await this.jobsService.deleteAll();
+  }
+
+  @UseGuards(CronApiTokenGuard)
+  @Post('cleanup')
+  async cleanup() {
+    this.jobsService.cleanup();
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/models/custom-job.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/models/custom-job.model.ts
@@ -66,6 +66,7 @@ export class CustomJob {
   public publishTime: number;
   public startTime: number;
   public endTime: number;
+  public createdAt: number;
 
   @Prop()
   public name: string;

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
@@ -9,6 +9,7 @@ export type JobDocument = Job & Document;
 @Schema({
   discriminatorKey: 'task',
   timestamps: { currentTime: MONGO_TIMESTAMP_FUNCTION, createdAt: true },
+  capped: { max: 300000 },
 })
 export class Job {
   @Prop({

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
@@ -1,11 +1,15 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 import { TimestampedString } from '../../../../types/timestamped-string.type';
+import { MONGO_TIMESTAMP_FUNCTION } from '../../database.constants';
 import { CustomJob } from './custom-job.model';
 
 export type JobDocument = Job & Document;
 
-@Schema({ discriminatorKey: 'task' })
+@Schema({
+  discriminatorKey: 'task',
+  timestamps: { currentTime: MONGO_TIMESTAMP_FUNCTION, createdAt: true },
+})
 export class Job {
   @Prop({
     type: String,
@@ -31,6 +35,9 @@ export class Job {
 
   @Prop()
   public endTime: number;
+
+  @Prop()
+  public createdAt: number;
 }
 
 export const JobSchema = SchemaFactory.createForClass(Job);

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/project.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/project.module.ts
@@ -5,6 +5,7 @@ import { DatalayerModule } from '../datalayer.module';
 import { JobsModule } from '../jobs/jobs.module';
 import { SecretsModule } from '../secrets/secrets.module';
 import { EventSubscriptionsModule } from '../subscriptions/event-subscriptions/event-subscriptions.module';
+import { SubscriptionTriggersModule } from '../subscriptions/subscription-triggers/subscription-triggers.module';
 import { DomainsModule } from './domain/domain.module';
 import { HostModule } from './host/host.module';
 import { PortModule } from './port/port.module';
@@ -22,6 +23,7 @@ import { ProjectService } from './project.service';
     PortModule,
     ConfigModule,
     SecretsModule,
+    SubscriptionTriggersModule,
   ],
   controllers: [ProjectController],
   providers: [ProjectService],

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/project.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/project.service.ts
@@ -8,6 +8,7 @@ import { JobsService } from '../jobs/jobs.service';
 import { SecretsService } from '../secrets/secrets.service';
 import { CronSubscription } from '../subscriptions/cron-subscriptions/cron-subscriptions.model';
 import { EventSubscriptionsService } from '../subscriptions/event-subscriptions/event-subscriptions.service';
+import { SubscriptionTriggersService } from '../subscriptions/subscription-triggers/subscription-triggers.service';
 import { DomainsService } from './domain/domain.service';
 import { CustomFinding } from './findings/finding.model';
 import { HostService } from './host/host.service';
@@ -29,6 +30,7 @@ export class ProjectService {
     private readonly findingModel: Model<CustomFinding>,
     private readonly portsService: PortService,
     private readonly secretsService: SecretsService,
+    private readonly triggerService: SubscriptionTriggersService,
   ) {}
 
   public async getAll(
@@ -97,6 +99,7 @@ export class ProjectService {
     await this.jobsService.deleteAllForProject(id);
     await this.subscriptionsService.deleteAllForProject(id);
     await this.portsService.deleteAllForProject(id);
+    await this.triggerService.deleteAllForProject(id);
     await this.findingModel.deleteMany({
       projectId: { $eq: new Types.ObjectId(id) },
     });

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.e2e-spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.e2e-spec.ts
@@ -1,10 +1,10 @@
 import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { useContainer } from 'class-validator';
-import * as request from 'supertest';
 import {
   TestingData,
   checkAuthorizations,
+  checkAuthorizationsCronApiKey,
   cleanup,
   deleteReq,
   getReq,
@@ -274,38 +274,19 @@ describe('Cron Subscriptions Controller (e2e)', () => {
   });
 
   it('Should have proper authorizations (POST /cron-subscriptions/{id}/notify)', async () => {
-    // Arrange
-    const path = `/cron-subscriptions/${subscriptionId}/notify`;
-
-    // Act & Assert
-    const call = async (givenToken: string) => {
-      return await postReq(app, givenToken, path);
-    };
-
-    let r = await call(testData.admin.token);
-    expect(r.statusCode).toStrictEqual(HttpStatus.FORBIDDEN);
-
-    r = await call(testData.user.token);
-    expect(r.statusCode).toStrictEqual(HttpStatus.FORBIDDEN);
-
-    r = await call(testData.readonly.token);
-    expect(r.statusCode).toStrictEqual(HttpStatus.FORBIDDEN);
-
-    r = await call('');
-    expect(r.statusCode).toStrictEqual(HttpStatus.FORBIDDEN);
-
-    r = await request(app.getHttpServer())
-      .post(path)
-      .set('Content-Type', 'application/json')
-      .set('x-stalker-cron', `asdf`)
-      .send({});
-    expect(r.statusCode).toStrictEqual(HttpStatus.FORBIDDEN);
-
-    r = await request(app.getHttpServer())
-      .post(path)
-      .set('Content-Type', 'application/json')
-      .set('x-stalker-cron', process.env.STALKER_CRON_API_TOKEN)
-      .send({});
-    expect(r.statusCode !== HttpStatus.FORBIDDEN).toStrictEqual(true);
+    const success = await checkAuthorizationsCronApiKey(
+      testData,
+      async (givenToken: string, headers, authenticate) => {
+        return await postReq(
+          app,
+          givenToken,
+          `/cron-subscriptions/${subscriptionId}/notify`,
+          undefined,
+          headers,
+          authenticate,
+        );
+      },
+    );
+    expect(success).toBe(true);
   });
 });

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { CustomJobNameExistsRule } from '../../../../validators/custom-job-name-exists.validator';
 import { CustomJobsModule } from '../../custom-jobs/custom-jobs.module';
+import { SubscriptionTriggersModule } from '../subscription-triggers/subscription-triggers.module';
 import { EventSubscriptionsController } from './event-subscriptions.controller';
 import { EventSubscriptionsSchema } from './event-subscriptions.model';
 import { eventSubscriptionsInitProvider } from './event-subscriptions.provider';
@@ -16,6 +17,7 @@ import { EventSubscriptionsService } from './event-subscriptions.service';
       },
     ]),
     CustomJobsModule,
+    SubscriptionTriggersModule,
   ],
   controllers: [EventSubscriptionsController],
   providers: [

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.service.ts
@@ -7,6 +7,7 @@ import {
   HttpNotFoundException,
 } from '../../../../exceptions/http.exceptions';
 import { ProjectUnassigned } from '../../../../validators/is-project-id.validator';
+import { SubscriptionTriggersService } from '../subscription-triggers/subscription-triggers.service';
 import { EVENT_SUBSCRIPTIONS_FILES_PATH } from '../subscriptions.constants';
 import { SubscriptionsUtils } from '../subscriptions.utils';
 import { EventSubscriptionDto } from './event-subscriptions.dto';
@@ -19,6 +20,7 @@ export class EventSubscriptionsService {
   constructor(
     @InjectModel('eventSubscriptions')
     private readonly subscriptionModel: Model<EventSubscription>,
+    private readonly triggerService: SubscriptionTriggersService,
   ) {}
 
   public async create(dto: EventSubscriptionDto) {
@@ -102,6 +104,7 @@ export class EventSubscriptionsService {
   }
 
   public async delete(id: string): Promise<DeleteResult> {
+    await this.triggerService.deleteAllForSubscription(id);
     return await this.subscriptionModel.deleteOne({
       _id: { $eq: new Types.ObjectId(id) },
     });
@@ -120,6 +123,7 @@ export class EventSubscriptionsService {
   }
 
   public async deleteAllForProject(projectId: string): Promise<DeleteResult> {
+    // The triggers will be deleted by the project, so no need to delete them here
     return await this.subscriptionModel.deleteMany({
       projectId: { $eq: new Types.ObjectId(projectId) },
     });

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.service.ts
@@ -111,4 +111,17 @@ export class SubscriptionTriggersService {
   public async getAll(): Promise<SubscriptionTriggerDocument[]> {
     return await this.subscriptionTriggerModel.find({});
   }
+
+  public async deleteAllForSubscription(subscriptionId: string) {
+    await this.subscriptionTriggerModel.deleteMany({
+      subscriptionId: { $eq: new Types.ObjectId(subscriptionId) },
+    });
+  }
+
+  public async deleteAllForProject(projectId: string) {
+    const r = new RegExp(`^project\:${projectId}`);
+    await this.subscriptionTriggerModel.deleteMany({
+      correlationKey: { $regex: r },
+    });
+  }
 }

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.controller.ts
@@ -2,24 +2,32 @@ import {
   BadRequestException,
   Controller,
   Get,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
 import { Page } from '../../types/page.type';
 import { Role } from '../auth/constants';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CronApiTokenGuard } from '../auth/guards/cron-api-token.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/role.guard';
 import { CustomFinding } from '../database/reporting/findings/finding.model';
 import { FindingsPagingDto } from './finding.dto';
 import { FindingsService } from './findings.service';
 
-@Roles(Role.ReadOnly)
-@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('findings')
 export class FindingsController {
   constructor(private readonly findingsService: FindingsService) {}
 
+  @UseGuards(CronApiTokenGuard)
+  @Post('cleanup')
+  async cleanup() {
+    this.findingsService.cleanup();
+  }
+
+  @Roles(Role.ReadOnly)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Get()
   async get(@Query() dto: FindingsPagingDto): Promise<Page<CustomFinding>> {
     if (dto.target == null || dto.target.trim() === '') {

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../../exceptions/http.exceptions';
 import { Page } from '../../types/page.type';
 import { ProjectUnassigned } from '../../validators/is-project-id.validator';
+import { ConfigService } from '../database/admin/config/config.service';
 import { JobsService } from '../database/jobs/jobs.service';
 import { CorrelationKeyUtils } from '../database/reporting/correlation.utils';
 import { CustomFinding } from '../database/reporting/findings/finding.model';
@@ -112,9 +113,23 @@ export class FindingsService {
     private commandBus: CommandBus,
     private jobsService: JobsService,
     private projectService: ProjectService,
+    private configService: ConfigService,
     @InjectModel('finding')
     private readonly findingModel: Model<CustomFinding>,
   ) {}
+
+  /**
+   * Deletes all the findings runs older than `config.jobRunRetentionTimeSeconds`.
+   */
+  public async cleanup(): Promise<void> {
+    const config = await this.configService.getConfig();
+    const ttlMilliseconds = config.findingRetentionTimeSeconds * 1000;
+    const now = Date.now();
+    const oldestValidCreationDate = now - ttlMilliseconds;
+    await this.findingModel.deleteMany({
+      $or: [{ created: { $lte: new Date(oldestValidCreationDate) } }],
+    });
+  }
 
   public async getAll(
     target: string,

--- a/packages/backend/jobs-manager/service/src/test/e2e.utils.ts
+++ b/packages/backend/jobs-manager/service/src/test/e2e.utils.ts
@@ -130,10 +130,20 @@ export async function getReq(
   app: INestApplication,
   token: string,
   path: string,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
 ) {
-  return await request(app.getHttpServer())
-    .get(path)
-    .set('Authorization', `Bearer ${token}`);
+  return await testRequest(
+    'get',
+    app,
+    token,
+    path,
+    null,
+    headers,
+    authenticate,
+  );
 }
 
 export async function postReq(
@@ -141,12 +151,20 @@ export async function postReq(
   token: string,
   path: string,
   data?: any,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
 ) {
-  return await request(app.getHttpServer())
-    .post(path)
-    .set('Content-Type', 'application/json')
-    .set('Authorization', `Bearer ${token}`)
-    .send(data);
+  return await testRequest(
+    'post',
+    app,
+    token,
+    path,
+    data,
+    headers,
+    authenticate,
+  );
 }
 
 export async function putReq(
@@ -154,12 +172,20 @@ export async function putReq(
   token: string,
   path: string,
   data: any,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
 ) {
-  return await request(app.getHttpServer())
-    .put(path)
-    .set('Content-Type', 'application/json')
-    .set('Authorization', `Bearer ${token}`)
-    .send(data);
+  return await testRequest(
+    'put',
+    app,
+    token,
+    path,
+    data,
+    headers,
+    authenticate,
+  );
 }
 
 export async function patchReq(
@@ -167,12 +193,20 @@ export async function patchReq(
   token: string,
   path: string,
   data: any,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
 ) {
-  return await request(app.getHttpServer())
-    .patch(path)
-    .set('Content-Type', 'application/json')
-    .set('Authorization', `Bearer ${token}`)
-    .send(data);
+  return await testRequest(
+    'patch',
+    app,
+    token,
+    path,
+    data,
+    headers,
+    authenticate,
+  );
 }
 
 export async function deleteReq(
@@ -180,18 +214,65 @@ export async function deleteReq(
   token: string,
   path: string,
   data: any = null,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
 ) {
-  if (data === null)
-    return await request(app.getHttpServer())
-      .delete(path)
-      .set('Content-Type', 'application/json')
-      .set('Authorization', `Bearer ${token}`);
+  return await testRequest(
+    'put',
+    app,
+    token,
+    path,
+    data,
+    headers,
+    authenticate,
+  );
+}
 
-  return await request(app.getHttpServer())
-    .delete(path)
-    .set('Content-Type', 'application/json')
-    .set('Authorization', `Bearer ${token}`)
-    .send(data);
+async function testRequest(
+  verb: 'get' | 'post' | 'put' | 'patch' | 'delete',
+  app: INestApplication,
+  token: string,
+  path: string,
+  data: any = null,
+  headers: { header: string; value: string }[] = [
+    { header: 'Content-Type', value: 'application/json' },
+  ],
+  authenticate: boolean = true,
+) {
+  let r: request.Test;
+  const server = request(app.getHttpServer());
+
+  switch (verb) {
+    case 'get':
+      r = server.get(path);
+      break;
+    case 'post':
+      r = server.post(path);
+      break;
+    case 'put':
+      r = server.put(path);
+      break;
+    case 'patch':
+      r = server.patch(path);
+      break;
+    case 'delete':
+      r = server.delete(path);
+      break;
+    default:
+      throw new Error();
+  }
+
+  for (const h of headers) {
+    r.set(h.header, h.value);
+  }
+
+  if (authenticate) {
+    r.set('Authorization', `Bearer ${token}`);
+  }
+
+  return await r.send(data);
 }
 
 /**
@@ -242,6 +323,45 @@ export async function checkAuthorizations(
   }
 
   return true;
+}
+
+export async function checkAuthorizationsCronApiKey(
+  data: TestingData,
+  call: (
+    token: string,
+    headers: { header: string; value: string }[],
+    authenticate: boolean,
+  ) => Promise<request.Response>,
+) {
+  let r = await call(data.admin.token, undefined, undefined);
+  if (r.statusCode !== HttpStatus.FORBIDDEN) return false;
+
+  r = await call(data.user.token, undefined, undefined);
+  if (r.statusCode !== HttpStatus.FORBIDDEN) return false;
+
+  r = await call(data.readonly.token, undefined, undefined);
+  if (r.statusCode !== HttpStatus.FORBIDDEN) return false;
+
+  r = await call('', undefined, undefined);
+  if (r.statusCode !== HttpStatus.FORBIDDEN) return false;
+
+  const cronHeaderName = 'x-stalker-cron';
+  const headers = [{ header: 'Content-Type', value: 'application/json' }];
+  r = await call(
+    null,
+    headers.concat([{ header: cronHeaderName, value: 'asdf' }]),
+    false,
+  );
+  if (r.statusCode !== HttpStatus.FORBIDDEN) return false;
+
+  r = await call(
+    null,
+    headers.concat([
+      { header: cronHeaderName, value: process.env.STALKER_CRON_API_TOKEN },
+    ]),
+    false,
+  );
+  if (r.statusCode === HttpStatus.FORBIDDEN) return false;
 }
 
 export async function createProject(


### PR DESCRIPTION
Adding generic cron reminders called `alarms` that can callback the jobs manager following a cron expression. It callback cleanup routes that address #263.

After this PR, findings will be stored for a year, and job runs for 14 days. Subscription triggers will have better cleanup on project/subscription deletion as well, reducing the need for a cleanup job.
