### PR TITLE
Adding the website resource and finding

### DIFF
--- a/docs/docs/concepts/findings.md
+++ b/docs/docs/concepts/findings.md
@@ -14,15 +14,16 @@ To produce a finding, the job must create an object containing the necessary inf
 
 The finding object must contain the `type` field. Here is a list of available types.
 
-| Type                                      | Description                                        |
-| ----------------------------------------- | -------------------------------------------------- |
-| [HostnameFinding](#hostnamefinding)       | Creates a new domain.                              |
-| [IpFinding](#ipfinding)                   | Creates a new host.                                |
-| [IpRangeFinding](#iprangefinding)         | Creates a new IP range.                            |
-| [HostnameIpFinding](#hostnameipfinding)   | Creates a new host, attaches it to a given domain. |
-| [PortFinding](#portfinding)               | Creates a new port, attaches it to the given host. |
-| [CustomFinding](#customfinding)           | Attaches custom finding data to a given entity.    |
-| [PortServiceFinding](#portservicefinding) | Fills the `service` field of a port.               |
+| Type                                      | Description                                                  |
+| ----------------------------------------- | ------------------------------------------------------------ |
+| [HostnameFinding](#hostnamefinding)       | Creates a new domain.                                        |
+| [IpFinding](#ipfinding)                   | Creates a new host.                                          |
+| [IpRangeFinding](#iprangefinding)         | Creates a new IP range.                                      |
+| [HostnameIpFinding](#hostnameipfinding)   | Creates a new host, attaches it to a given domain.           |
+| [PortFinding](#portfinding)               | Creates a new port, attaches it to the given host.           |
+| [WebsiteFinding](#websiteFinding)         | Creates a new website, with the proper host, domain and port |
+| [CustomFinding](#customfinding)           | Attaches custom finding data to a given entity.              |
+| [PortServiceFinding](#portservicefinding) | Fills the `service` field of a port.                         |
 
 ## HostnameFinding
 
@@ -186,7 +187,7 @@ Using the python SDK, you can emit this finding with the following code:
 ```python
 from stalker_job_sdk import PortFinding, log_finding
 port = 80
-ip = "0.0.0.0"
+ip = "1.2.3.4"
 log_finding(
     PortFinding(
         "PortFinding",
@@ -196,6 +197,60 @@ log_finding(
         "New port",
         [TextField("protocol", "This is a TCP port", "tcp")],
         "PortFinding",
+    )
+)
+```
+
+## WebsiteFinding
+
+The `WebsiteFinding` will create a website resource. Websites are made from 4 characteristics: an IP address, a domain name, a port number and a path. Only the IP address and the port are mandatory. The domain can be empty and the path will default to `/`.
+
+To create a website, it must reference an existing port of a project. To reference a domain as well, it must also be a domain already known to Stalker.
+
+It signals that an open port running an http(s) service, either `tcp` or `udp`, has been found on the host specified through the `ip` value. The `ip` must already be known to Stalker as a valid host. A port finding creates or updates a port
+and attaches it to the given host.
+
+> Emitting a `PortServiceFinding` with a `serviceName` of `http` and `https` will result in creating a `WebsiteFinding` per domain linked to the host, and one with an empty domain. [Learn more about PortServiceFinding and websites](#portservicefinding-and-websites)
+
+| Field    | Description                                             |
+| -------- | ------------------------------------------------------- |
+| `ip`     | The ip                                                  |
+| `port`   | The port number                                         |
+| `domain` | The domain on which the website is hosted, can be empty |
+| `path`   | The folder path, defaults to `/`                        |
+
+Example:
+
+```json
+{
+  "type": "WebsiteFinding",
+  "key": "WebsiteFinding",
+  "ip": "1.2.3.4",
+  "port": 80,
+  "domain": "example.com",
+  "path": "/"
+}
+```
+
+Using the python SDK, you can emit this finding with the following code:
+
+```python
+from stalker_job_sdk import WebsiteFinding, log_finding
+port = 80
+ip = "1.2.3.4"
+domain = "example.com"
+path = "/"
+
+log_finding(
+    WebsiteFinding(
+        "WebsiteFinding",
+        ip,
+        port,
+        domain,
+        path,
+        "New website",
+        [],
+        "WebsiteFinding",
     )
 )
 ```
@@ -343,3 +398,44 @@ log_finding(
 ```
 
 Upon receiving this finding, the backend will set the service database field of the TCP port 22 for the `0.0.0.0` IP to `ssh`.
+
+### PortServiceFinding and websites
+
+When publishing a `PortServiceFinding` with the service name of `http` or `https`, the `Jobs Manager` will understand that a website is located on that port.
+
+The `Jobs Manager` will therefore create and publish several `WebsiteFinding`s, one for each of the host's linked domain name, and one for the IP address alone.
+
+These website findings will allow further investigation of the http(s) port with the different domain names, in case the port supporting multiple virutal hosts.
+
+For instance, imagine a host with the IP address `1.2.3.4`. This host has the linked domains `example.com` and `dev.example.com`.
+
+Then, with the following code publishing the results for an https port:
+
+```python
+from stalker_job_sdk import PortFinding, log_finding, TextField
+
+ip = '1.2.3.4'
+port = 443
+protocol = 'tcp'
+service_name = 'https'
+
+fields = [
+  TextField("serviceName", "Service name", service_name)
+]
+
+log_finding(
+    PortFinding(
+        "PortServiceFinding", ip, port, protocol, f"Found service {service_name}", fields
+    )
+)
+```
+
+We would create the following three websites:
+
+| domain          | host    | port | path |
+| --------------- | ------- | ---- | ---- |
+| N/A             | 1.2.3.4 | 443  | `/`  |
+| example.com     | 1.2.3.4 | 443  | `/`  |
+| dev.example.com | 1.2.3.4 | 443  | `/`  |
+
+That way, a website at `dev.example.com`, which may be different than the one at `example.com`, will be found. The same goes for the website through direct IP access.

--- a/docs/docs/concepts/resources.md
+++ b/docs/docs/concepts/resources.md
@@ -58,6 +58,33 @@ A port can be created with a `PortFinding`. A port finding is a combination of a
 
 The combination of a port's number and host identifier is unique in the database.
 
+### Websites
+
+A website represents a `tcp` port running an http(s) server.
+
+A website is the combination between a port, a host, a domain and a path. The path, when not specified, defaults to `/`. The domain can also be empty, as not all websites have domains that resolve to them.
+
+A website is usually created for each http(s) port for each domain linked to a host.
+
+Therefore, if a host runs two http(s) ports with two domains, a total of 6 websites on the `/` path are possible. Let's take the domains `dev.example.com` and `example.com`, the IP `1.2.3.4` and the ports `80` and `443` for the `/` path.
+
+The following 6 values are possible:
+
+| domain          | host    | port | path |
+| --------------- | ------- | ---- | ---- |
+|                 | 1.2.3.4 | 80   | /    |
+| example.com     | 1.2.3.4 | 80   | /    |
+| dev.example.com | 1.2.3.4 | 80   | /    |
+|                 | 1.2.3.4 | 443  | /    |
+| example.com     | 1.2.3.4 | 443  | /    |
+| dev.example.com | 1.2.3.4 | 443  | /    |
+
+Ports are used, combined with a *host*'s IP address, to represent a network service. Every port is linked to a *host*. They can be seen in the user interface under the `Ports` page.
+
+A website can be created with a `WebsiteFinding`. A website finding is a combination of an IP, a port, a domain and a path. Therefore, when a website is created, it is automatically linked to the given port, host and domain.
+
+The combination of a websites's port identifier, domain identifier and path is unique in the database.
+
 ## Interacting with resources
 
 ### Tagging a resource
@@ -81,3 +108,7 @@ While deleted resources are removed from the database, blocked resources will st
 Blocked resources can be seen in the user interface by removing the default filter `-is: blocked`. Every resource will be shown that way, blocked or not. If you wish to only see the blocked resources, use the `is: blocked` filter.
 
 Blocking a resource is useful if, through automation, Stalker found a resource that does not belong in the project. Deleting it would likely result in it reappearing later and jobs being run on it. Blocking it will ensure that jobs are not automatically run on the resource by remembering its existence.
+
+### Merging websites
+
+> This feature is not yet available, but is coming soon.

--- a/jobs/job-base-images/python/stalker_job_sdk/stalker_job_sdk/__init__.py
+++ b/jobs/job-base-images/python/stalker_job_sdk/stalker_job_sdk/__init__.py
@@ -74,6 +74,23 @@ class PortFinding(Finding):
         self.port = port
         self.protocol = protocol
 
+class WebsiteFinding(Finding):
+    def __init__(
+        self,
+        key: str,
+        ip: str,
+        port: int,
+        domain: str,
+        path: str,
+        name: str = None,
+        fields: list[Field] = [],
+        type: str = "CustomFinding",
+    ):
+        super().__init__(key, type, name, fields)
+        self.ip = ip
+        self.port = port
+        self.domain = domain
+        self.path = path
 
 class DomainFinding(Finding):
     def __init__(

--- a/packages/backend/jobs-manager/service/src/modules/database/datalayer.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/datalayer.module.ts
@@ -9,6 +9,7 @@ import { FindingModelModule } from './reporting/findings/findings-model.module';
 import { HostModelModule } from './reporting/host/host-model.module';
 import { PortModelModule } from './reporting/port/port-model.module';
 import { ProjectModelModule } from './reporting/project-model.module';
+import { WebsiteModelModule } from './reporting/websites/website-model.module';
 import { SecretsModelModule } from './secrets/secrets-model.module';
 import { CronSubscriptionModelModule } from './subscriptions/cron-subscriptions/cron-subscription-model.module';
 import { TagModelModule } from './tags/tag-model.module';
@@ -27,6 +28,7 @@ import { TagModelModule } from './tags/tag-model.module';
     CronSubscriptionModelModule,
     SecretsModelModule,
     CustomJobTemplateModelModule,
+    WebsiteModelModule,
   ],
   providers: [...databaseConfigInitProvider],
   exports: [
@@ -42,6 +44,8 @@ import { TagModelModule } from './tags/tag-model.module';
     CronSubscriptionModelModule,
     SecretsModelModule,
     CustomJobTemplateModelModule,
+    WebsiteModelModule,
+    DomainModelModule,
   ],
 })
 export class DatalayerModule {}

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/correlation.utils.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/correlation.utils.spec.ts
@@ -18,7 +18,7 @@ describe('Finding utils', () => {
   it('Port findings key', () => {
     // Arrange
     // Act
-    const correlationId = CorrelationKeyUtils.portCorrelationKey(
+    const correlationKey = CorrelationKeyUtils.portCorrelationKey(
       '507f1f77bcf86cd799439011',
       '1.2.3.4',
       443,
@@ -26,7 +26,7 @@ describe('Finding utils', () => {
     );
 
     // Assert
-    expect(correlationId).toBe(
+    expect(correlationKey).toBe(
       `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp`,
     );
   });
@@ -34,14 +34,79 @@ describe('Finding utils', () => {
   it('Domain findings key', () => {
     // Arrange
     // Act
-    const correlationId = CorrelationKeyUtils.domainCorrelationKey(
+    const correlationKey = CorrelationKeyUtils.domainCorrelationKey(
       '507f1f77bcf86cd799439011',
       'www.stalker.is',
     );
 
     // Assert
-    expect(correlationId).toBe(
+    expect(correlationKey).toBe(
       `project:507f1f77bcf86cd799439011;domain:www.stalker.is`,
+    );
+  });
+
+  it('Ip range findings key', () => {
+    // Arrange
+    // Act
+    const correlationKey = CorrelationKeyUtils.ipRangeCorrelationKey(
+      '507f1f77bcf86cd799439011',
+      '1.2.3.4',
+      24,
+    );
+
+    // Assert
+    expect(correlationKey).toBe(
+      `project:507f1f77bcf86cd799439011;host:1.2.3.4;mask:24`,
+    );
+  });
+
+  it('Website findings key', () => {
+    // Arrange
+    // Act
+    const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+      '507f1f77bcf86cd799439011',
+      '1.2.3.4',
+      443,
+      'example.com',
+      '/example/',
+    );
+
+    // Assert
+    expect(correlationKey).toBe(
+      `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:example.com;path:/example/`,
+    );
+  });
+
+  it('Website findings key, no domain', () => {
+    // Arrange
+    // Act
+    const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+      '507f1f77bcf86cd799439011',
+      '1.2.3.4',
+      443,
+      '',
+      '/example/',
+    );
+
+    // Assert
+    expect(correlationKey).toBe(
+      `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:;path:/example/`,
+    );
+  });
+
+  it('Website findings key, no path', () => {
+    // Arrange
+    // Act
+    const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+      '507f1f77bcf86cd799439011',
+      '1.2.3.4',
+      443,
+      'example.com',
+    );
+
+    // Assert
+    expect(correlationKey).toBe(
+      `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:example.com;path:/`,
     );
   });
 
@@ -88,6 +153,179 @@ describe('Finding utils', () => {
 
       // Assert
       expect(name).toBe('DomainsService');
+    });
+
+    it('Website findings key', () => {
+      // Arrange
+      const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        '1.2.3.4',
+        443,
+        'example.com',
+        '/example/',
+      );
+
+      // Act
+      const name = CorrelationKeyUtils.getResourceServiceName(correlationKey);
+
+      // Assert
+      expect(name).toBe('WebsiteService');
+    });
+
+    it('Website findings key, no domain', () => {
+      // Arrange
+      const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        '1.2.3.4',
+        443,
+        '',
+        '/example/',
+      );
+
+      // Act
+      const name = CorrelationKeyUtils.getResourceServiceName(correlationKey);
+
+      // Assert
+      expect(name).toBe('WebsiteService');
+    });
+
+    it('Website findings key, no path', () => {
+      // Arrange
+      const correlationKey = CorrelationKeyUtils.websiteCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        '1.2.3.4',
+        443,
+        'example.com',
+      );
+
+      // Act
+      const name = CorrelationKeyUtils.getResourceServiceName(correlationKey);
+
+      // Assert
+      expect(name).toBe('WebsiteService');
+    });
+  });
+
+  describe('Generic key generation', () => {
+    it('Host findings key', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        null,
+        '1.2.3.4',
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4`,
+      );
+    });
+
+    it('Port findings key', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        null,
+        '1.2.3.4',
+        443,
+        'tcp',
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp`,
+      );
+    });
+
+    it('Domain findings key', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        'www.stalker.is',
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;domain:www.stalker.is`,
+      );
+    });
+
+    it('Ip range findings key', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        null,
+        '1.2.3.4',
+        null,
+        null,
+        24,
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4;mask:24`,
+      );
+    });
+
+    it('Website findings key', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        'example.com',
+        '1.2.3.4',
+        443,
+        'tcp',
+        null,
+        '/example/',
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:example.com;path:/example/`,
+      );
+    });
+
+    it('Website findings key, no domain', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        '',
+        '1.2.3.4',
+        443,
+        'tcp',
+        null,
+        '/example/',
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:;path:/example/`,
+      );
+    });
+
+    it('Website findings key, no path', () => {
+      // Arrange
+      // Act
+      const correlationKey = CorrelationKeyUtils.generateCorrelationKey(
+        '507f1f77bcf86cd799439011',
+        'example.com',
+        '1.2.3.4',
+        443,
+        'tcp',
+        null,
+        null,
+      );
+
+      // Assert
+      expect(correlationKey).toBe(
+        `project:507f1f77bcf86cd799439011;host:1.2.3.4;port:443;protocol:tcp;domain:example.com;path:/`,
+      );
     });
   });
 });

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/port/port.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/port/port.model.ts
@@ -11,7 +11,7 @@ export class Port {
   public host: HostSummary;
 
   @Prop()
-  public projectId?: Types.ObjectId;
+  public projectId: Types.ObjectId;
 
   /**
    * A pseudo-unique key identifying this entity. Used for findings.

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/port/port.summary.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/port/port.summary.ts
@@ -1,15 +1,15 @@
 import { Prop } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 
-export interface DomainSummary {
+export interface PortSummary {
   id: Types.ObjectId;
-  name: string;
+  port: number;
 }
 
-export class DomainSummaryType implements DomainSummary {
+export class PortSummaryType implements PortSummary {
   @Prop()
   id: Types.ObjectId;
 
   @Prop()
-  name: string;
+  port: number;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/project.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/project.module.ts
@@ -10,6 +10,7 @@ import { HostModule } from './host/host.module';
 import { PortModule } from './port/port.module';
 import { ProjectController } from './project.controller';
 import { ProjectService } from './project.service';
+import { WebsiteModule } from './websites/website.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ProjectService } from './project.service';
     PortModule,
     ConfigModule,
     SecretsModule,
+    WebsiteModule,
   ],
   controllers: [ProjectController],
   providers: [ProjectService],

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/project.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/project.service.ts
@@ -14,6 +14,7 @@ import { HostService } from './host/host.service';
 import { PortService } from './port/port.service';
 import { CreateProjectDto } from './project.dto';
 import { Project, ProjectDocument } from './project.model';
+import { WebsiteService } from './websites/website.service';
 
 @Injectable()
 export class ProjectService {
@@ -29,6 +30,7 @@ export class ProjectService {
     private readonly findingModel: Model<CustomFinding>,
     private readonly portsService: PortService,
     private readonly secretsService: SecretsService,
+    private readonly websiteService: WebsiteService,
   ) {}
 
   public async getAll(
@@ -97,6 +99,7 @@ export class ProjectService {
     await this.jobsService.deleteAllForProject(id);
     await this.subscriptionsService.deleteAllForProject(id);
     await this.portsService.deleteAllForProject(id);
+    await this.websiteService.deleteAllForProject(id);
     await this.findingModel.deleteMany({
       projectId: { $eq: new Types.ObjectId(id) },
     });

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website-filter.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website-filter.model.ts
@@ -1,0 +1,16 @@
+export class WebsitePagingModel {
+  page: string;
+  pageSize: string;
+}
+
+export class WebsiteFilterModel {
+  domain?: Array<string>;
+  tags?: Array<string>;
+  project?: Array<string>;
+  host?: Array<string>;
+  port?: Array<number>;
+  firstSeenStartDate?: number;
+  firstSeenEndDate?: number;
+  blocked?: boolean;
+  merged?: boolean;
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website-model.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website-model.module.ts
@@ -1,0 +1,9 @@
+import { MongooseModule } from '@nestjs/mongoose';
+import { WebsiteSchema } from './website.model';
+
+export const WebsiteModelModule = MongooseModule.forFeature([
+  {
+    name: 'websites',
+    schema: WebsiteSchema,
+  },
+]);

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { WebsiteService } from './website.service';
+
+@Controller('websites')
+export class WebsiteController {
+  constructor(private readonly portsService: WebsiteService) {}
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.e2e-spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.e2e-spec.ts
@@ -1,0 +1,171 @@
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { randomUUID } from 'crypto';
+import {
+  TestingData,
+  checkAuthorizations,
+  cleanup,
+  createDomain as createDomains,
+  createProject,
+  deleteReq,
+  getReq,
+  initTesting,
+  patchReq,
+  postReq,
+  putReq,
+} from '../../../../test/e2e.utils';
+import { AppModule } from '../../../app.module';
+import { Role } from '../../../auth/constants';
+import { WebsiteService } from './website.service';
+
+describe('Website Controller (e2e)', () => {
+  let app: INestApplication;
+  let testData: TestingData;
+
+  let moduleFixture: TestingModule;
+  let portsService: WebsiteService;
+  const testPrefix = 'website-controller-e2e-';
+
+  beforeAll(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    portsService = await moduleFixture.resolve(WebsiteService);
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    testData = await initTesting(app);
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("GET a host's ports /ports", () => {
+    it('Should get the TCP ports of a host without ports (GET /ports/)', async () => {
+      // Arrange
+      const project = await createProject(app, testData, getName());
+      const domain = 'www.example.org';
+      await createDomains(app, testData, project._id, [domain]);
+      const rHost = await postReq(app, testData.admin.token, `/hosts`, {
+        ips: ['192.168.2.1'],
+        projectId: project._id.toString(),
+      });
+
+      const hostId = rHost.body[0]._id;
+
+      // Act
+      const r = await getReq(
+        app,
+        testData.admin.token,
+        `/ports/?hostId=${hostId}&page=0&pageSize=10&protocol=tcp`,
+      );
+
+      // Assert
+      expect(r.statusCode).toBe(HttpStatus.OK);
+      expect(r.body.items.length).toStrictEqual(0);
+      expect(r.body.totalRecords).toStrictEqual(0);
+    });
+  });
+
+  it('Should have proper authorizations (GET /ports/:id)', async () => {
+    const success = await checkAuthorizations(
+      testData,
+      Role.ReadOnly,
+      async (givenToken) => {
+        return await getReq(app, givenToken, `/ports/6450827d0ae00198f250672d`);
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  it('Should have proper authorizations (PUT /ports/:id/tags)', async () => {
+    const success = await checkAuthorizations(
+      testData,
+      Role.User,
+      async (givenToken) => {
+        return await putReq(
+          app,
+          givenToken,
+          `/ports/6450827d0ae00198f250672d/tags`,
+          {},
+        );
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  it('Should have proper authorizations (GET /ports)', async () => {
+    // Arrange
+    const project = await createProject(app, testData, getName());
+    const domain = 'www.example.org';
+    await createDomains(app, testData, project._id, [domain]);
+    const rHost = await postReq(app, testData.admin.token, `/hosts`, {
+      ips: ['192.168.2.1'],
+      projectId: project._id.toString(),
+    });
+
+    const hostId = rHost.body[0]._id;
+
+    const success = await checkAuthorizations(
+      testData,
+      Role.ReadOnly,
+      async (givenToken) => {
+        return await getReq(app, givenToken, `/ports?`);
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  it('Should have proper authorizations (DELETE /ports/:id)', async () => {
+    const success = await checkAuthorizations(
+      testData,
+      Role.User,
+      async (givenToken) => {
+        return await deleteReq(
+          app,
+          givenToken,
+          `/ports/6450827d0ae00198f250672d`,
+          {},
+        );
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  it('Should have proper authorizations (DELETE /ports/)', async () => {
+    const success = await checkAuthorizations(
+      testData,
+      Role.User,
+      async (givenToken) => {
+        return await deleteReq(app, givenToken, `/ports/`, {});
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  it('Should have proper authorizations (PATCH /ports/)', async () => {
+    const success = await checkAuthorizations(
+      testData,
+      Role.User,
+      async (givenToken) => {
+        return await patchReq(app, givenToken, `/ports/`, {});
+      },
+    );
+    expect(success).toBe(true);
+  });
+
+  function getName() {
+    return `${testPrefix}-${randomUUID()}`;
+  }
+});

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.model.ts
@@ -1,0 +1,77 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+import { MONGO_TIMESTAMP_SCHEMA_CONFIG } from '../../database.constants';
+import { DomainSummary, DomainSummaryType } from '../domain/domain.summary';
+import { HostSummary, HostSummaryType } from '../host/host.summary';
+import { PortSummary, PortSummaryType } from '../port/port.summary';
+
+export type WebsiteDocument = Website & Document;
+
+@Schema(MONGO_TIMESTAMP_SCHEMA_CONFIG)
+export class Website {
+  @Prop({ type: HostSummaryType })
+  public host: HostSummary;
+
+  @Prop({ type: Array<HostSummaryType> })
+  public alternativeHosts?: HostSummary[];
+
+  @Prop({ type: DomainSummaryType })
+  public domain?: DomainSummary;
+
+  @Prop({ type: Array<DomainSummaryType> })
+  public alternativeDomains?: DomainSummary[];
+
+  @Prop({ type: PortSummaryType })
+  public port: PortSummary;
+
+  @Prop({ type: Array<PortSummaryType> })
+  public alternativePorts?: PortSummary[];
+
+  @Prop()
+  public path: string;
+
+  @Prop()
+  public sitemap: string[];
+
+  @Prop()
+  public previewImage: string;
+
+  @Prop()
+  public projectId?: Types.ObjectId;
+
+  /**
+   * A pseudo-unique key identifying this entity. Used for findings.
+   * This key should not change if this entity were to be recreated.
+   */
+  @Prop()
+  public correlationKey!: string;
+
+  @Prop()
+  public tags?: Types.ObjectId[];
+
+  @Prop()
+  public updatedAt: number;
+
+  @Prop()
+  public createdAt: number;
+
+  @Prop()
+  public lastSeen: number;
+
+  @Prop()
+  public blocked?: boolean;
+
+  @Prop()
+  public blockedAt?: number;
+
+  @Prop()
+  public mergedInId?: Types.ObjectId;
+}
+
+export const WebsiteSchema = SchemaFactory.createForClass(Website);
+
+// The project id and host id are not included here as the port id - host id - projectId combination is already unique
+WebsiteSchema.index(
+  { 'port.id': 1, 'domain.id': 1, path: 1 },
+  { unique: true },
+);

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { QueueModule } from '../../../job-queue/queue.module';
+import { DatalayerModule } from '../../datalayer.module';
+import { TagsModule } from '../../tags/tag.module';
+import { WebsiteController } from './website.controller';
+import { WebsiteService } from './website.service';
+
+@Module({
+  imports: [DatalayerModule, TagsModule, QueueModule],
+  controllers: [WebsiteController],
+  providers: [WebsiteService],
+  exports: [WebsiteService],
+})
+export class WebsiteModule {}

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.service.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.service.spec.ts
@@ -1,0 +1,204 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getName } from '../../../../test/test.utils';
+import { AppModule } from '../../../app.module';
+import { TagsService } from '../../tags/tag.service';
+import { DomainsService } from '../domain/domain.service';
+import { HostService } from '../host/host.service';
+import { CreateProjectDto } from '../project.dto';
+import { ProjectService } from '../project.service';
+
+import { PortService } from '../port/port.service';
+import { WebsiteService } from './website.service';
+
+describe('Website Service', () => {
+  let moduleFixture: TestingModule;
+  let hostService: HostService;
+  let domainService: DomainsService;
+  let projectService: ProjectService;
+  let tagsService: TagsService;
+  let portService: PortService;
+  let websiteService: WebsiteService;
+  const testPrefix = 'website-service-ut';
+
+  beforeAll(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    hostService = moduleFixture.get(HostService);
+    domainService = moduleFixture.get(DomainsService);
+    projectService = moduleFixture.get(ProjectService);
+    tagsService = moduleFixture.get(TagsService);
+    portService = moduleFixture.get(PortService);
+    websiteService = moduleFixture.get(WebsiteService);
+  });
+
+  beforeEach(async () => {
+    const allProjects = await projectService.getAll();
+    for (const c of allProjects) {
+      await projectService.delete(c._id);
+    }
+    const tags = await tagsService.getAll();
+    for (const t of tags) {
+      tagsService.delete(t._id);
+    }
+  });
+
+  afterAll(async () => {
+    await moduleFixture.close();
+  });
+
+  describe('Add websites', () => {
+    it('Should create a website for a host without domain or path', async () => {
+      // Arrange
+      const portNumber = 22;
+      const c = await project();
+      const h = await host('1.1.1.1', c._id.toString());
+      const p = await port(portNumber, h[0]._id.toString(), c._id.toString());
+
+      // Act
+      const w1 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+      );
+
+      // Assert
+      expect(w1._id).toBeTruthy();
+      expect(w1.port.id.toString()).toStrictEqual(p._id.toString());
+      expect(w1.host.id.toString()).toStrictEqual(h[0]._id.toString());
+      expect(w1.path).toStrictEqual('/');
+      expect(w1.domain).toBeNull();
+    });
+
+    it('Should create a website for a host with domain without path', async () => {
+      // Arrange
+      const portNumber = 22;
+      const domainName = 'example.com';
+      const c = await project();
+      const h = await host('1.1.1.1', c._id.toString());
+      const p = await port(portNumber, h[0]._id.toString(), c._id.toString());
+      const d = await domain(domainName, c._id.toString());
+
+      // Act
+      const w1 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+        domainName,
+      );
+
+      // Assert
+      expect(w1._id).toBeTruthy();
+      expect(w1.port.id.toString()).toStrictEqual(p._id.toString());
+      expect(w1.host.id.toString()).toStrictEqual(h[0]._id.toString());
+      expect(w1.path).toStrictEqual('/');
+      expect(w1.domain.name).toStrictEqual(domainName);
+    });
+
+    it('Should create a website for a host with domain and path', async () => {
+      // Arrange
+      const portNumber = 22;
+      const domainName = 'example.com';
+      const path = '/example/asdf/';
+      const c = await project();
+      const h = await host('1.1.1.1', c._id.toString());
+      const p = await port(portNumber, h[0]._id.toString(), c._id.toString());
+      const d = await domain(domainName, c._id.toString());
+
+      // Act
+      const w1 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+        domainName,
+        path,
+      );
+
+      // Assert
+      expect(w1._id).toBeTruthy();
+      expect(w1.port.id.toString()).toStrictEqual(p._id.toString());
+      expect(w1.host.id.toString()).toStrictEqual(h[0]._id.toString());
+      expect(w1.path).toStrictEqual(path);
+      expect(w1.domain.name).toStrictEqual(domainName);
+    });
+
+    it('Should create a website for a host without domain, but with path', async () => {
+      // Arrange
+      const portNumber = 22;
+      const path = '/example/asdf/';
+      const c = await project();
+      const h = await host('1.1.1.1', c._id.toString());
+      const p = await port(portNumber, h[0]._id.toString(), c._id.toString());
+
+      // Act
+      const w1 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+        '',
+        path,
+      );
+
+      // Assert
+      expect(w1._id).toBeTruthy();
+      expect(w1.port.id.toString()).toStrictEqual(p._id.toString());
+      expect(w1.host.id.toString()).toStrictEqual(h[0]._id.toString());
+      expect(w1.path).toStrictEqual(path);
+      expect(w1.domain).toBeNull();
+    });
+
+    it('Should not create a second website for twice the same host-port-domain-project', async () => {
+      // Arrange
+      const portNumber = 22;
+      const path = '/example/asdf/';
+      const domainName = 'example.com';
+      const c = await project();
+      const h = await host('1.1.1.1', c._id.toString());
+      const p = await port(portNumber, h[0]._id.toString(), c._id.toString());
+      const d = await domain(domainName, c._id.toString());
+      const w1 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+        domainName,
+        path,
+      );
+
+      // Act
+      const w2 = await websiteService.addWebsite(
+        c._id.toString(),
+        h[0].ip,
+        portNumber,
+        domainName,
+        path,
+      );
+
+      // Assert
+      const allWebsites = await websiteService.getAll();
+      expect(allWebsites.length).toStrictEqual(1);
+      expect(allWebsites[0]._id.toString()).toStrictEqual(w1._id.toString());
+    });
+  });
+
+  async function project(name: string = '') {
+    const ccDto: CreateProjectDto = { name: `${getName(testPrefix)}` };
+    return await projectService.addProject(ccDto);
+  }
+
+  async function host(ip: string, projectId: string) {
+    return await hostService.addHosts([ip], projectId);
+  }
+
+  async function domain(name: string, projectId: string) {
+    return await domainService.addDomain(name, projectId);
+  }
+
+  async function port(
+    port: number,
+    hostId: string,
+    projectId: string,
+    protocol: 'tcp' | 'udp' = 'tcp',
+  ) {
+    return await portService.addPort(hostId, projectId, port, protocol);
+  }
+});

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/websites/website.service.ts
@@ -1,0 +1,232 @@
+import { Injectable, Logger, NotImplementedException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { DeleteResult } from 'mongodb';
+import { FilterQuery, Model, Types } from 'mongoose';
+import { HttpNotFoundException } from '../../../../exceptions/http.exceptions';
+import { WebsiteFinding } from '../../../findings/findings.service';
+import { FindingsQueue } from '../../../job-queue/findings-queue';
+import { TagsService } from '../../tags/tag.service';
+import { CorrelationKeyUtils } from '../correlation.utils';
+import { Domain } from '../domain/domain.model';
+import { DomainSummary } from '../domain/domain.summary';
+import { Host } from '../host/host.model';
+import { Port } from '../port/port.model';
+import { WebsiteFilterModel } from './website-filter.model';
+import { Website, WebsiteDocument } from './website.model';
+
+@Injectable()
+export class WebsiteService {
+  private logger = new Logger(WebsiteService.name);
+
+  constructor(
+    @InjectModel('websites') private readonly websiteModel: Model<Website>,
+    @InjectModel('domain') private readonly domainModel: Model<Domain>,
+    @InjectModel('host') private readonly hostModel: Model<Host>,
+    @InjectModel('port') private readonly portModel: Model<Port>,
+    private findingsQueue: FindingsQueue,
+    private tagsService: TagsService,
+  ) {}
+
+  public async addWebsite(
+    projectId: string,
+    ip: string,
+    port: number,
+    domain: string = undefined,
+    path: string = '/',
+  ) {
+    const projectIdObj = new Types.ObjectId(projectId);
+    const existingPort = await this.portModel.findOne({
+      'host.ip': { $eq: ip },
+      port: { $eq: port },
+      projectId: { $eq: projectIdObj },
+      layer4Protocol: { $eq: 'tcp' },
+    });
+
+    if (!existingPort) {
+      this.logger.error(
+        `Failed to add a website because the port did not exist (project: ${projectId}, IP: ${ip}, port: ${port})`,
+      );
+      throw new HttpNotFoundException();
+    }
+
+    // Validate the domain
+    let existingDomainSummary: DomainSummary = undefined;
+    if (domain) {
+      const existingDomain = await this.domainModel.findOne(
+        {
+          projectId: { $eq: projectIdObj },
+          name: { $eq: domain },
+        },
+        '_id name',
+      );
+
+      if (existingDomain) {
+        existingDomainSummary = {
+          id: existingDomain._id,
+          name: existingDomain.name,
+        };
+      } else {
+        this.logger.error(
+          `Domain not found while adding a website (project: ${projectId}, domain: ${domain})`,
+        );
+        throw new HttpNotFoundException();
+      }
+    } else {
+      existingDomainSummary = undefined;
+    }
+
+    // Search for a website with the proper port id, domain and path.
+    // domain may or may not exist, it depends if it was found in the domains collection
+    const searchQuery: FilterQuery<Website> = {
+      'port.id': { $eq: existingPort._id },
+      'domain.id': {
+        $eq: existingDomainSummary ? existingDomainSummary.id : null,
+      },
+      path: { $eq: path },
+    };
+
+    return this.websiteModel.findOneAndUpdate(
+      searchQuery,
+      {
+        $set: { lastSeen: Date.now() },
+        $setOnInsert: {
+          host: existingPort.host,
+          domain: existingDomainSummary ?? null,
+          port: { id: existingPort._id, port: existingPort.port },
+          path: path,
+          sitemap: ['/'],
+          projectId: projectIdObj,
+          correlationKey: CorrelationKeyUtils.websiteCorrelationKey(
+            projectId,
+            ip,
+            port,
+            existingDomainSummary ? existingDomainSummary.name : '',
+            path,
+          ),
+        },
+      },
+      { upsert: true, new: true },
+    );
+  }
+
+  /**
+   * This method creates a WebsiteFinding for each domain linked to the host,
+   * as well as one for the host's direct ip port access, without a domain.
+   * @param jobId
+   * @param projectId
+   * @param ip
+   * @param port
+   * @param path
+   * @returns
+   */
+  public async emitWebsiteFindingsForAllHostDomains(
+    jobId: string,
+    projectId: string,
+    ip: string,
+    port: number,
+    path: string = '/',
+  ) {
+    const host = await this.hostModel.findOne({
+      ip: { $eq: ip },
+      projectId: { $eq: new Types.ObjectId(projectId) },
+    });
+
+    if (!host) {
+      this.logger.error(
+        `Failed to add the websites because the host did not exist (project: ${projectId}, IP: ${ip})`,
+      );
+      throw new HttpNotFoundException();
+    }
+
+    const websiteFindingBase: Omit<WebsiteFinding, 'domain'> = {
+      type: 'WebsiteFinding',
+      key: 'WebsiteFinding',
+      ip: ip,
+      path: path,
+      port: port,
+      fields: [],
+    };
+
+    // We will create a website finding
+    let findings: WebsiteFinding[] = [
+      {
+        domain: '',
+        ...websiteFindingBase,
+      },
+    ];
+
+    for (const domainSummary of host.domains) {
+      findings.push({
+        domain: domainSummary.name,
+        ...websiteFindingBase,
+      });
+
+      if (findings.length >= 10) {
+        await this.findingsQueue.publish(...findings);
+        findings = [];
+      }
+    }
+
+    this.findingsQueue.publishForJob(jobId, ...findings);
+  }
+
+  public async deleteAllForProject(projectId: string): Promise<DeleteResult> {
+    return await this.websiteModel.deleteMany({
+      projectId: { $eq: new Types.ObjectId(projectId) },
+    });
+  }
+
+  public async delete(websiteId: string): Promise<DeleteResult> {
+    return await this.websiteModel.deleteOne({
+      _id: { $eq: new Types.ObjectId(websiteId) },
+    });
+  }
+
+  public async get(websiteId: string) {
+    return await this.websiteModel.findById(websiteId);
+  }
+
+  public async getAll(
+    page: number = null,
+    pageSize: number = null,
+    filter: WebsiteFilterModel = null,
+  ): Promise<WebsiteDocument[]> {
+    let query;
+    if (filter) {
+      query = this.websiteModel.find(this.buildFilters(filter));
+    } else {
+      query = this.websiteModel.find({});
+    }
+
+    if (page != null && pageSize != null) {
+      query = query.skip(page * pageSize).limit(pageSize);
+    }
+    return await query;
+  }
+
+  private async buildFilters(filter: WebsiteFilterModel) {
+    throw new NotImplementedException();
+  }
+
+  public async keyIsBlocked(correlationKey: string) {
+    const website = await this.websiteModel.findOne(
+      { correlationKey: { $eq: correlationKey } },
+      'blocked mergedInId',
+    );
+    return website && (!!website.mergedInId || website.blocked);
+  }
+
+  /**
+   * TODO:
+   *
+   * When a host is deleted:
+   *  delete the websites for the host
+   *  unlink the host if in alternative hosts
+   * When a domain is deleted:
+   *   delete the websites for the domain
+   *   unlink the domain if in alternative domains
+   * When a port is deleted:
+   *   delete the websites for the port
+   *   unlink the port if in alternative ports
+   */
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.module.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { DomainsModule } from '../../reporting/domain/domain.module';
 import { HostModule } from '../../reporting/host/host.module';
 import { PortModule } from '../../reporting/port/port.module';
+import { WebsiteModule } from '../../reporting/websites/website.module';
 import { SubscriptionTriggersController } from './subscription-triggers.controller';
 import { SubscriptionTriggerSchema } from './subscription-triggers.model';
 import { SubscriptionTriggersService } from './subscription-triggers.service';
@@ -18,6 +19,7 @@ import { SubscriptionTriggersService } from './subscription-triggers.service';
     HostModule,
     DomainsModule,
     PortModule,
+    WebsiteModule,
   ],
   controllers: [SubscriptionTriggersController],
   providers: [SubscriptionTriggersService],

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscription-triggers/subscription-triggers.service.ts
@@ -6,6 +6,7 @@ import { CorrelationKeyUtils } from '../../reporting/correlation.utils';
 import { DomainsService } from '../../reporting/domain/domain.service';
 import { HostService } from '../../reporting/host/host.service';
 import { PortService } from '../../reporting/port/port.service';
+import { WebsiteService } from '../../reporting/websites/website.service';
 import {
   SubscriptionTrigger,
   SubscriptionTriggerDocument,
@@ -21,6 +22,7 @@ export class SubscriptionTriggersService {
     private readonly hostsService: HostService,
     private readonly domainsService: DomainsService,
     private readonly portsService: PortService,
+    private readonly websiteService: WebsiteService,
   ) {}
 
   public async isTriggerBlocked(correlationKey: string): Promise<boolean> {
@@ -34,6 +36,8 @@ export class SubscriptionTriggersService {
         return await this.domainsService.keyIsBlocked(correlationKey);
       case 'HostService':
         return await this.hostsService.keyIsBlocked(correlationKey);
+      case 'WebsiteService':
+        return await this.websiteService.keyIsBlocked(correlationKey);
       default:
         return false;
     }

--- a/packages/backend/jobs-manager/service/src/modules/findings/commands/JobFindings/website.command.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/commands/JobFindings/website.command.ts
@@ -1,0 +1,13 @@
+import { WebsiteFinding } from '../../findings.service';
+import { JobFindingCommand } from '../findings.command';
+
+export class WebsiteCommand extends JobFindingCommand {
+  constructor(
+    jobId: string,
+    projectId: string,
+    commandType: string,
+    public readonly finding: WebsiteFinding,
+  ) {
+    super(jobId, projectId, commandType);
+  }
+}

--- a/packages/backend/jobs-manager/service/src/modules/findings/commands/JobFindings/website.handler.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/commands/JobFindings/website.handler.ts
@@ -1,0 +1,45 @@
+import { Logger } from '@nestjs/common';
+import { CommandHandler } from '@nestjs/cqrs';
+import { ConfigService } from '../../../database/admin/config/config.service';
+import { CustomJobsService } from '../../../database/custom-jobs/custom-jobs.service';
+import { JobsService } from '../../../database/jobs/jobs.service';
+import { WebsiteService } from '../../../database/reporting/websites/website.service';
+import { SecretsService } from '../../../database/secrets/secrets.service';
+import { EventSubscriptionsService } from '../../../database/subscriptions/event-subscriptions/event-subscriptions.service';
+import { SubscriptionTriggersService } from '../../../database/subscriptions/subscription-triggers/subscription-triggers.service';
+import { JobFindingHandlerBase } from '../job-findings-handler-base';
+import { WebsiteCommand } from './website.command';
+
+@CommandHandler(WebsiteCommand)
+export class WebsiteHandler extends JobFindingHandlerBase<WebsiteCommand> {
+  protected logger: Logger = new Logger('WebsiteHandler');
+
+  constructor(
+    private websiteService: WebsiteService,
+    jobService: JobsService,
+    subscriptionsService: EventSubscriptionsService,
+    customJobsService: CustomJobsService,
+    configService: ConfigService,
+    subscriptionTriggersService: SubscriptionTriggersService,
+    secretsService: SecretsService,
+  ) {
+    super(
+      jobService,
+      subscriptionsService,
+      customJobsService,
+      configService,
+      subscriptionTriggersService,
+      secretsService,
+    );
+  }
+
+  protected async executeCore(command: WebsiteCommand) {
+    await this.websiteService.addWebsite(
+      command.projectId,
+      command.finding.ip,
+      command.finding.port,
+      command.finding.domain,
+      command.finding.path,
+    );
+  }
+}

--- a/packages/backend/jobs-manager/service/src/modules/findings/commands/findings-commands.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/commands/findings-commands.ts
@@ -8,6 +8,8 @@ import { HostnameIpCommand } from './JobFindings/hostname-ip.command';
 import { HostnameIpHandler } from './JobFindings/hostname-ip.handler';
 import { PortCommand } from './JobFindings/port.command';
 import { PortHandler } from './JobFindings/port.handler';
+import { WebsiteCommand } from './JobFindings/website.command';
+import { WebsiteHandler } from './JobFindings/website.handler';
 
 export const FindingsCommandMapping = [
   {
@@ -29,6 +31,11 @@ export const FindingsCommandMapping = [
     finding: 'PortFinding',
     handler: PortHandler,
     command: PortCommand,
+  },
+  {
+    finding: 'WebsiteFinding',
+    handler: WebsiteHandler,
+    command: WebsiteCommand,
   },
   {
     finding: 'CustomFinding',

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.module.ts
@@ -11,6 +11,7 @@ import { DomainsModule } from '../database/reporting/domain/domain.module';
 import { HostModule } from '../database/reporting/host/host.module';
 import { PortModule } from '../database/reporting/port/port.module';
 import { ProjectModule } from '../database/reporting/project.module';
+import { WebsiteModule } from '../database/reporting/websites/website.module';
 import { SecretsModule } from '../database/secrets/secrets.module';
 import { EventSubscriptionsModule } from '../database/subscriptions/event-subscriptions/event-subscriptions.module';
 import { SubscriptionTriggersModule } from '../database/subscriptions/subscription-triggers/subscription-triggers.module';
@@ -35,6 +36,7 @@ import { JobLogsConsumer } from './job-logs.consumer';
     ConfigModule,
     SubscriptionTriggersModule,
     SecretsModule,
+    WebsiteModule,
   ],
   controllers: [FindingsController],
   providers: [FindingsService, ...FindingsHandlers],

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.service.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.service.spec.ts
@@ -130,7 +130,6 @@ describe('Findings Service Spec', () => {
     [undefined, undefined, undefined],
     ['example.org', undefined, 80],
     ['example.org', '1.1.1.1', undefined],
-    ['example.org', '1.1.1.1', 80],
     [undefined, undefined, 1],
   ])(
     'Save - Invalid finding correlation information - Throws',

--- a/packages/backend/jobs-manager/service/src/modules/job-queue/findings-queue.ts
+++ b/packages/backend/jobs-manager/service/src/modules/job-queue/findings-queue.ts
@@ -2,4 +2,9 @@ import { Finding } from '../findings/findings.service';
 
 export abstract class FindingsQueue {
   public abstract publish(...findings: Finding[]): Promise<void>;
+
+  public abstract publishForJob(
+    jobId: string,
+    ...findings: Finding[]
+  ): Promise<void>;
 }

--- a/packages/backend/jobs-manager/service/src/modules/job-queue/kafka-findings-queue.ts
+++ b/packages/backend/jobs-manager/service/src/modules/job-queue/kafka-findings-queue.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Message, Producer } from 'kafkajs';
 import { orchestratorConstants } from '../auth/constants';
+import { Finding } from '../findings/findings.service';
 import { FindingsQueue } from './findings-queue';
 
 @Injectable()
@@ -10,6 +11,13 @@ export class KafkaFindingsQueue implements FindingsQueue {
   constructor(private producer: Producer) {}
 
   public async publish(...findings: any[]) {
+    this.publishForJob(undefined, ...findings);
+  }
+
+  public async publishForJob(
+    jobId?: string,
+    ...findings: Finding[]
+  ): Promise<void> {
     this.logger.debug(
       `Publishing ${findings.length} findings to the message queue on topic ${
         orchestratorConstants.topics.findings
@@ -21,6 +29,7 @@ export class KafkaFindingsQueue implements FindingsQueue {
         key: null,
         value: JSON.stringify({
           FindingsJson: JSON.stringify({ findings: findings }),
+          JobId: jobId,
         }),
       },
     ];

--- a/packages/backend/jobs-manager/service/src/modules/job-queue/null-findings-queue.ts
+++ b/packages/backend/jobs-manager/service/src/modules/job-queue/null-findings-queue.ts
@@ -6,6 +6,10 @@ export class NullFindingsQueue implements FindingsQueue {
   private logger = new Logger(NullFindingsQueue.name);
 
   public async publish(...findings: any[]) {
+    this.publishForJob(undefined, ...findings);
+  }
+
+  public async publishForJob(...findings: any[]) {
     this.logger.debug('Findings not posted to findings queue.');
   }
 }


### PR DESCRIPTION
#### This PR is the first of multiple PRs

With this new resource and finding, it is possible to represent websites in the database.

When a `PortServiceFinding` with a `serviceName` of `http` or `https` is emitted by a job, the jobs manager recognises that this is a website and emits a `WebsiteFinding` for every combination of a host's linked domains.

It is done this way because a port scan does not have the domain information with it, and anyway, any domain that resolves to a host could have a different website for the same port through the concept of _virtual hosts_.

A website is the combination of a domain (can be empty), a host, a port and a path (defaults to `/`). The reason behind the path is that several websites could be routed by a proxy, resulting in a different website at a different path.

This PR does not include any interface, but it will eventually get its own view. Cleanup is also lacking a little bit.

> You can ignore the "new" e2e tests here. They are a copy paste from ports and will be fully changed in the next PR