### PR TITLE
Giving variables with any job as a debug log

### DIFF
--- a/packages/backend/orchestrator/service/Orchestrator/Events/JobLogsProducer.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Events/JobLogsProducer.cs
@@ -8,4 +8,15 @@ public class JobLogsProducer : MessagesProducer<JobLogMessage>
 
     public JobLogsProducer(IConfiguration config, ILogger<KafkaConsumer<JobLogMessage>> logger) : base(new JsonSerializer<JobLogMessage>(), config, logger)
     { }
+
+    public async void LogDebug(string? JobId, string message)
+    {
+        await Produce(new JobLogMessage()
+        {
+            JobId = JobId,
+            Log = message,
+            LogLevel = Events.LogLevel.Debug,
+            Timestamp = TimeUtils.CurrentTimeMs()
+        });
+    }
 }

--- a/packages/backend/orchestrator/service/Orchestrator/Jobs/Commands/NucleiCustomJobCommand.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Jobs/Commands/NucleiCustomJobCommand.cs
@@ -11,7 +11,7 @@ public class NucleiCustomJobCommand : KubernetesCommand<CustomJobRequest>
 {
     protected override KubernetesJobTemplate JobTemplate { get; }
 
-    public NucleiCustomJobCommand(CustomJobRequest request, JobModel model, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, IMessagesProducer<JobLogMessage> jobLogsProducer, IFindingsParser parser, ILogger<NucleiCustomJobCommand> logger, IConfiguration config)
+    public NucleiCustomJobCommand(CustomJobRequest request, JobModel model, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, JobLogsProducer jobLogsProducer, IFindingsParser parser, ILogger<NucleiCustomJobCommand> logger, IConfiguration config)
         : base(request, kubernetes, eventsProducer, jobLogsProducer, parser, logger)
     {
         JobTemplate = new NucleiCustomJobTemplate(request.JobId, config, request.CustomJobParameters, model.Code, request.JobPodMilliCpuLimit, request.JobPodMemoryKbLimit, model.FindingHandler, model.Image);

--- a/packages/backend/orchestrator/service/Orchestrator/Jobs/Commands/PythonCustomJobCommand.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Jobs/Commands/PythonCustomJobCommand.cs
@@ -11,7 +11,7 @@ public class PythonCustomJobCommand : KubernetesCommand<CustomJobRequest>
 {
     protected override KubernetesJobTemplate JobTemplate { get; }
 
-    public PythonCustomJobCommand(CustomJobRequest request, JobModel model, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, IMessagesProducer<JobLogMessage> jobLogsProducer, IFindingsParser parser, ILogger<PythonCustomJobCommand> logger, IConfiguration config)
+    public PythonCustomJobCommand(CustomJobRequest request, JobModel model, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, JobLogsProducer jobLogsProducer, IFindingsParser parser, ILogger<PythonCustomJobCommand> logger, IConfiguration config)
         : base(request, kubernetes, eventsProducer, jobLogsProducer, parser, logger)
     {
         JobTemplate = new PythonCustomJobTemplate(request.JobId, config, request.CustomJobParameters, model.Code, request.JobPodMilliCpuLimit, request.JobPodMemoryKbLimit, model.Image);

--- a/packages/backend/orchestrator/service/Orchestrator/Jobs/JobFactory.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Jobs/JobFactory.cs
@@ -48,13 +48,14 @@ public class JobFactory : IJobFactory
         if (request.JobModelId == null) throw new InvalidOperationException();
 
         int maxParamValueDisplayLength = 100;
-        string truncatedString = "[TRUNCATED]";
+        string truncatedString = "[REDACTED]";
 
         var model = JobModelCache.JobModelCache.Get(request.JobModelId);
 
         if (!request.CustomJobParameters.IsNullOrEmpty())
         {
             List<string> logInfo = new List<string>();
+            JobLogsProducer.LogDebug(request.JobId!, "Job started with the following input:");
             foreach (var parameter in request.CustomJobParameters!)
             {
                 string value = parameter.Value ?? "";
@@ -66,12 +67,8 @@ public class JobFactory : IJobFactory
                 {
                     value = string.Concat(value.AsSpan(0, maxParamValueDisplayLength), "[...]");
                 }
-                logInfo.Add(string.Concat(parameter.Name, ":", value));
+                JobLogsProducer.LogDebug(request.JobId!, string.Concat("- ", parameter.Name, ": ", value));
             }
-
-            string output = string.Concat("Parameters: ", string.Join(", ", logInfo));
-
-            JobLogsProducer.LogDebug(request.JobId!, output);
         } 
         else
         {

--- a/packages/backend/orchestrator/service/Orchestrator/Jobs/KubernetesCommand.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Jobs/KubernetesCommand.cs
@@ -9,14 +9,14 @@ public abstract class KubernetesCommand<T> : JobCommand where T : JobRequest
 {
     private IKubernetesFacade Kubernetes { get; }
     private IMessagesProducer<JobEventMessage> EventsProducer { get; }
-    private IMessagesProducer<JobLogMessage> LogsProducer { get; }
+    private JobLogsProducer LogsProducer { get; }
     private IFindingsParser Parser { get; }
     private ILogger Logger { get; }
     protected T Request { get; }
 
     protected abstract KubernetesJobTemplate JobTemplate { get; }
 
-    protected KubernetesCommand(T request, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, IMessagesProducer<JobLogMessage> jobLogsProducer, IFindingsParser parser, ILogger logger)
+    protected KubernetesCommand(T request, IKubernetesFacade kubernetes, IMessagesProducer<JobEventMessage> eventsProducer, JobLogsProducer jobLogsProducer, IFindingsParser parser, ILogger logger)
     {
         Request = request;
         Kubernetes = kubernetes;
@@ -26,78 +26,20 @@ public abstract class KubernetesCommand<T> : JobCommand where T : JobRequest
         Logger = logger;
     }
 
-    /// <summary>
-    /// Waits for a scaling amount of time everytime you call it, according to the iteration parameter
-    /// Does not wait for the first iteration
-    /// During 10 seconds, wait for 100ms for every call (100i)
-    /// During 20 seconds, wait for 200ms for every call (100i)
-    /// During 30 seconds, wait for 300ms for every call (100i)
-    /// During 4 minutes, wait for 1000ms for every call (240i)
-    /// During 5 minutes, wait for 5000ms for every call (60i)
-    /// During 20 minutes, wait for 20000ms for every call (60i)
-    /// If the function is called more than 660 times total (660i), wait for 30000ms for every call
-    /// </summary>
-    private static void ScalingSleep(int iteration)
-    {
-        int waitTime;
-        if (iteration == 0)
-        {
-            waitTime = 0;
-        }
-        else if (iteration <= 300)
-        {
-            waitTime = (iteration / 100) + 100;
-        }
-        else if (iteration > 300 && iteration <= 540)
-        {
-            waitTime = 1000;
-        }
-        else if (iteration > 540 && iteration <= 600)
-        {
-            waitTime = 5000;
-        }
-        else if (iteration > 600 && iteration <= 660)
-        {
-            waitTime = 20000;
-        }
-        else
-        {
-            waitTime = 30000;
-        }
-        Thread.Sleep(waitTime);
-    }
-
-    private long CurrentTimeMs()
-    {
-        DateTimeOffset dto = new DateTimeOffset(DateTime.Now.ToUniversalTime());
-        return dto.ToUnixTimeMilliseconds();
-    }
 
     public override async Task Execute()
     {
         Logger.LogInformation(Request.JobId, "Creating job.");
 
         var job = await Kubernetes.CreateJob(JobTemplate);
-        await LogDebug("Job picked up by orchestrator.");
+        LogsProducer.LogDebug(Request.JobId, "Job picked up by orchestrator.");
         Logger.LogInformation(Request.JobId, "Job created, listening for events.");
 
         await EventsProducer.Produce(new JobEventMessage
         {
             JobId = Request.JobId,
             FindingsJson = "{ \"findings\": [{ \"type\": \"JobStatusFinding\", \"status\": \"Started\" }]}",
-            Timestamp = CurrentTimeMs(),
+            Timestamp = TimeUtils.CurrentTimeMs(),
         });
-
-        // Local functions
-        async Task LogDebug(string message)
-        {
-            await LogsProducer.Produce(new JobLogMessage()
-            {
-                JobId = Request.JobId,
-                Log = message,
-                LogLevel = Events.LogLevel.Debug,
-                Timestamp = CurrentTimeMs()
-            });
-        }
     }
 }

--- a/packages/backend/orchestrator/service/Orchestrator/Utils/CryptoUtils.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Utils/CryptoUtils.cs
@@ -7,7 +7,7 @@ namespace Orchestrator.Utils
     {
         private static readonly string PrivateKeyEnvironementVariable = "SECRET_PRIVATE_RSA_KEY";
         private static readonly RSACryptoServiceProvider RSA = InitRsa();
-        public static readonly string SecretPrefix = "$$secret$$";
+        private static readonly string SecretPrefix = "$$secret$$";
 
         private static RSACryptoServiceProvider InitRsa()
         {
@@ -25,7 +25,7 @@ namespace Orchestrator.Utils
         /// <returns>The decrypted value, or the value unchanged if it did not start with <see cref="CryptoUtils.SecretPrefix"/></returns>
         public static string Decrypt(string value)
         {
-            if (!value.StartsWith(SecretPrefix)) return value;
+            if (!IsSecret(value)) return value;
 
             var returnValue = value;
 
@@ -42,6 +42,11 @@ namespace Orchestrator.Utils
             }
 
             return returnValue;
+        }
+
+        public static bool IsSecret(string value)
+        {
+            return value.StartsWith(SecretPrefix);
         }
 
     }

--- a/packages/backend/orchestrator/service/Orchestrator/Utils/TimeUtils.cs
+++ b/packages/backend/orchestrator/service/Orchestrator/Utils/TimeUtils.cs
@@ -1,0 +1,8 @@
+public static class TimeUtils
+{
+    public static long CurrentTimeMs()
+    {
+        DateTimeOffset dto = new DateTimeOffset(DateTime.Now.ToUniversalTime());
+        return dto.ToUnixTimeMilliseconds();
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c3952109-9124-4619-ac05-0038f3381a6f)

The orchestrator now gives the parameters information as a debug log on all executions. The value is not given if it was a secret, and is truncated if it was too long.