### PR TITLE
Input batching for cron subscriptions

### DIFF
--- a/docs/docs/concepts/subscriptions.md
+++ b/docs/docs/concepts/subscriptions.md
@@ -79,13 +79,16 @@ job:
 The `input` variable specifies an input source. There are multiple input sources described in the following table. The `input` variable is
 optionnal. The variables can be injected in the job parameters as well as in the conditions.
 
-If a project is specified, only the ressources of the targeted project will be used.
+If a project is specified for the subscription, only the ressources of the targeted project will be used.
 
-| Input source  | Variables                         |
-| ------------- | --------------------------------- |
-| ALL_DOMAINS   | `${domainName}`                   |
-| ALL_HOSTS     | `${ip}`                           |
-| ALL_TCP_PORTS | `${ip}`, `${port}`, `${protocol}` |
+
+| Input source  | Variables                                                               | Batching variables                                                                                |
+| ------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| ALL_DOMAINS   | `${domainName}`                                                         | `${domainBatch}`                                                                                  |
+| ALL_HOSTS     | `${ip}`                                                                 | `${ipBatch}`                                                                                      |
+| ALL_TCP_PORTS | `${ip}`, `${port}`, `${protocol}`                                       | `${ipBatch}`, `${portBatch}`, `${protocolBatch}`                                                  |
+| ALL_IP_RANGES | `${ip}`, `${mask}`                                                      | `${ipBatch}`, `${maskBatch}`                                                                      |
+| ALL_WEBSITES  | `${domainName}`, `${ip}`, `${port}`, `${protocol}`, `${ssl}`, `${path}` | `${domainBatch}`, `${ipBatch}`, `${portBatch}`, `${protocolBatch}`, `${sslBatch}`, `${pathBatch}` |
 
 When you specify the `ALL_DOMAINS` input, you have access to the `${domainName}` injectable variable. Red Kite will apply the subscription
 for all the domains, and the domain's value will be injected where specified.
@@ -202,6 +205,87 @@ job:
       value: 10
     - name: extraOptions
       value: -jc -kf all -duc -j -or -ob -silent
+```
+
+##### Batching job inputs
+
+The cron subscription batching syntax can be used to launch a job with mulitple values as input. Instead of giving a standard string as input like the standard way of making a cron subscription, the batching syntax would give you an array of strings up to the specified size.
+
+For instance, the following subscription will start a `DomainNameResolvingJob` by giving an array of up to 100 domain names in the `domainNames` parameter using the `domainBatch` input variable.
+
+> [All the possible input variables are listed in the table here.](#input-variable)
+
+```yaml
+name: Refreshing all domain names
+input: ALL_DOMAINS
+batch:
+  enabled: true
+  size: 100
+cronExpression: "0 0 */7 * *"
+job:
+  name: DomainNameResolvingJob
+  parameters:
+    - name: domainNames
+      value: ${domainBatch}
+```
+
+Some ressources, like ports, provide multiple values as input to a cron subscription. When the batching syntax is used, all the values will be given in seperate arrays, and all the values at an index `i` belong to the same resource. Therefore, all the arrays will have the same length.
+
+For instance, if you have three ports in the database with the following characteristics:
+
+| Index | Port | IP      | Protocol |
+| ----- | ---- | ------- | -------- |
+| 0     | 22   | 1.1.1.1 | tcp      |
+| 1     | 80   | 2.2.2.2 | tcp      |
+| 2     | 443  | 3.3.3.3 | tcp      |
+
+And a cron subscription like the following:
+
+```yaml
+name: Example cron subscription
+input: ALL_TCP_PORTS
+batch:
+  enabled: true   # Input batching is enabled
+  size: 100       # with a max size of 100 items per array per job
+cronExpression: "0 0 */7 * *"
+job:
+  name: PortExampleJob
+  parameters:
+    - name: targetIps
+      value: ${ipBatch}
+    - name: ports
+      value: ${portBatch}
+    - name: protocols
+      value: ${protocolBatch}
+```
+
+You would end up with the following parameters after the injection of values by the backend:
+
+```yaml
+  parameters:
+    - name: targetIps
+      value: ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+    - name: ports
+      value: [22, 80, 443]
+    - name: protocols
+      value: ['tcp', 'tcp', 'tcp']
+```
+
+Which would be usable in the following way, in python:
+
+```python
+import os
+import json
+
+ips = json.loads(os.environ.get("targetIps"))       # ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+ports = json.loads(os.environ.get("ports"))         # [22, 80, 443]
+protocols = json.loads(os.environ.get("protocols")) # ['tcp', 'tcp', 'tcp']
+```
+
+The batch size of 100, with only three ports in the database, resulted in the launch of only one job. However, if we had 10 ports in the database, and a batch size of 3, you would end up starting 4 jobs, following the logic 
+
+```text
+ceiling(10 / 3) => 4
 ```
 
 ## Event Subscriptions

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 title: Overview
 description: An overview of Red Kite
 ---

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
@@ -29,7 +29,7 @@ import { ConfigService } from '../admin/config/config.service';
 import { JobPodConfiguration } from '../admin/config/job-pod-config/job-pod-config.model';
 import { CustomJobsService } from '../custom-jobs/custom-jobs.service';
 import { SecretsService } from '../secrets/secrets.service';
-import { JobParameter } from '../subscriptions/event-subscriptions/event-subscriptions.model';
+import { JobParameter } from '../subscriptions/subscriptions.type';
 import { JobExecutionsService } from './job-executions.service';
 import { JobDefinitions } from './job-model.module';
 import { JobExecutionsDto, StartJobDto } from './jobs.dto';

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.dto.ts
@@ -10,8 +10,8 @@ import {
 } from 'class-validator';
 import { PagingDto } from '../database.dto';
 import { FilterByProjectDto } from '../reporting/resource.dto';
-import { JobParameter } from '../subscriptions/event-subscriptions/event-subscriptions.model';
 import { JobParameterDto } from '../subscriptions/subscriptions.dto';
+import { JobParameter } from '../subscriptions/subscriptions.type';
 
 export class JobExecutionsDto extends IntersectionType(
   PagingDto,

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.factory.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.factory.spec.ts
@@ -8,7 +8,7 @@ import { JobPodConfiguration } from '../admin/config/job-pod-config/job-pod-conf
 import { ProjectService } from '../reporting/project.service';
 import { Secret } from '../secrets/secrets.model';
 import { SecretsService } from '../secrets/secrets.service';
-import { JobParameter } from '../subscriptions/event-subscriptions/event-subscriptions.model';
+import { JobParameter } from '../subscriptions/subscriptions.type';
 import { JobExecutionsService } from './job-executions.service';
 import { JobFactoryUtils } from './jobs.factory';
 import { Job } from './models/jobs.model';

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.factory.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.factory.ts
@@ -13,7 +13,7 @@ import {
   CustomJobsDocument,
 } from '../custom-jobs/custom-jobs.model';
 import { SecretsService } from '../secrets/secrets.service';
-import { JobParameter } from '../subscriptions/event-subscriptions/event-subscriptions.model';
+import { JobParameter } from '../subscriptions/subscriptions.type';
 import { JobDefinitions } from './job-model.module';
 import { CustomJob } from './models/custom-job.model';
 import { Job } from './models/jobs.model';

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/models/custom-job.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/models/custom-job.model.ts
@@ -18,7 +18,7 @@ import {
   environmentVariableRegex,
 } from '../../../../utils/linux-environment-variables.utils';
 import { isProjectId } from '../../../../validators/is-project-id.validator';
-import { JobParameter } from '../../subscriptions/event-subscriptions/event-subscriptions.model';
+import { JobParameter } from '../../subscriptions/subscriptions.type';
 import { JobFactoryUtils } from '../jobs.factory';
 import { Job } from './jobs.model';
 

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.controller.ts
@@ -19,11 +19,11 @@ import { CronApiTokenGuard } from '../../../auth/guards/cron-api-token.guard';
 import { RolesGuard } from '../../../auth/guards/role.guard';
 import { ApiKeyStrategy } from '../../../auth/strategies/api-key.strategy';
 import { JwtStrategy } from '../../../auth/strategies/jwt.strategy';
-import { PatchSubscriptionDto } from '../subscriptions.dto';
 import {
-  CronSubscriptionDto,
-  DuplicateCronSubscriptionDto,
-} from './cron-subscriptions.dto';
+  DuplicateSubscriptionDto,
+  PatchSubscriptionDto,
+} from '../subscriptions.dto';
+import { CronSubscriptionDto } from './cron-subscriptions.dto';
 import { CronSubscriptionsDocument } from './cron-subscriptions.model';
 import { CronSubscriptionsService } from './cron-subscriptions.service';
 
@@ -34,9 +34,7 @@ export class CronSubscriptionsController {
   @UseGuards(AuthGuard([JwtStrategy.name, ApiKeyStrategy.name]), RolesGuard)
   @Roles(Role.User)
   @Post()
-  async create(
-    @Body() dto: CronSubscriptionDto | DuplicateCronSubscriptionDto,
-  ) {
+  async create(@Body() dto: CronSubscriptionDto | DuplicateSubscriptionDto) {
     if ('subscriptionId' in dto) {
       return await this.subscriptionsService.duplicate(dto.subscriptionId);
     } else {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
@@ -1,66 +1,42 @@
 import { Type } from 'class-transformer';
 import {
-  IsArray,
   IsBoolean,
   IsIn,
-  IsMongoId,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
+  Min,
   ValidateNested,
 } from 'class-validator';
-import { CustomJobNameExists } from '../../../../validators/custom-job-name-exists.validator';
+import { DependsOn } from '../../../../validators/depends-on.validator';
 import { IsCronExpression } from '../../../../validators/is-cron-expression.validator';
-import { IsValidJobConditionsArray } from '../../../../validators/is-valid-job-conditions-array.validator';
-import {
-  AndJobCondition,
-  JobCondition,
-  OrJobCondition,
-} from '../event-subscriptions/event-subscriptions.model';
-import { JobParameterDto } from '../subscriptions.dto';
+import { BaseSubscriptionDto } from '../subscriptions.dto';
 import { InputSource, inputSources } from './cron-subscriptions.model';
 
-export class DuplicateCronSubscriptionDto {
-  @IsMongoId()
-  @IsNotEmpty()
-  @IsString()
-  public subscriptionId: string;
+export class CronSubscriptionBatchingDto {
+  @IsBoolean()
+  enabled: boolean;
+
+  @Min(1)
+  @IsNumber()
+  @IsOptional()
+  size?: number;
 }
 
-export class CronSubscriptionDto {
-  @IsString()
-  @IsNotEmpty()
-  public name!: string;
-
-  @IsBoolean()
-  @IsOptional()
-  public isEnabled?: boolean;
-
-  @IsMongoId()
-  @IsOptional()
-  public projectId?: string; // if projectId is not set, the subscription is for all projects
-
+export class CronSubscriptionDto extends BaseSubscriptionDto {
   @IsString()
   @IsNotEmpty()
   @IsCronExpression()
   public cronExpression!: string;
 
-  @IsString()
-  @IsNotEmpty()
-  @CustomJobNameExists()
-  public jobName!: string;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => JobParameterDto)
-  @IsOptional()
-  public jobParameters?: JobParameterDto[];
-
   @IsIn(inputSources)
   @IsOptional()
   public input?: InputSource;
 
-  @IsValidJobConditionsArray()
+  @ValidateNested()
+  @DependsOn('input')
   @IsOptional()
-  public conditions?: Array<JobCondition | OrJobCondition | AndJobCondition>;
+  @Type(() => CronSubscriptionBatchingDto)
+  public batch: CronSubscriptionBatchingDto;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
@@ -38,5 +38,5 @@ export class CronSubscriptionDto extends BaseSubscriptionDto {
   @DependsOn('input')
   @IsOptional()
   @Type(() => CronSubscriptionBatchingDto)
-  public batch: CronSubscriptionBatchingDto;
+  public batch?: CronSubscriptionBatchingDto;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.model.ts
@@ -4,15 +4,11 @@ import { DataSource } from '../../data-source/data-source.model';
 import {
   AndJobCondition,
   JobCondition,
+  JobParameter,
   OrJobCondition,
-} from '../event-subscriptions/event-subscriptions.model';
+} from '../subscriptions.type';
 
 export type CronSubscriptionsDocument = CronSubscription & Document;
-
-export class JobParameter {
-  public name!: string;
-  public value!: unknown;
-}
 
 export const inputSources = [
   'ALL_DOMAINS',
@@ -23,6 +19,14 @@ export const inputSources = [
 ] as const;
 
 export type InputSource = (typeof inputSources)[number];
+
+export class CronSubscriptionBatching {
+  @Prop()
+  enabled: boolean;
+
+  @Prop()
+  size?: number;
+}
 
 @Schema()
 export class CronSubscription {
@@ -37,6 +41,9 @@ export class CronSubscription {
 
   @Prop()
   public input?: InputSource;
+
+  @Prop()
+  public batch?: CronSubscriptionBatching;
 
   @Prop()
   public cronExpression!: string;

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.service.ts
@@ -27,12 +27,12 @@ import { ProjectService } from '../../reporting/project.service';
 import { WebsiteDocument } from '../../reporting/websites/website.model';
 import { WebsiteService } from '../../reporting/websites/website.service';
 import { SecretsService } from '../../secrets/secrets.service';
+import { JobParameter } from '../subscriptions.type';
 import { SubscriptionsUtils } from '../subscriptions.utils';
 import { CronSubscriptionDto } from './cron-subscriptions.dto';
 import {
   CronSubscription,
   CronSubscriptionsDocument,
-  JobParameter,
 } from './cron-subscriptions.model';
 
 @Injectable()
@@ -59,6 +59,7 @@ export class CronSubscriptionsService {
       isEnabled: dto.isEnabled == null ? dto.isEnabled : true,
       name: dto.name,
       input: dto.input ? dto.input : null,
+      batch: dto.batch,
       cronExpression: dto.cronExpression,
       jobName: dto.jobName,
       jobParameters: dto.jobParameters,
@@ -89,6 +90,7 @@ export class CronSubscriptionsService {
       projectId: existingSub.projectId,
       cronExpression: existingSub.cronExpression,
       input: existingSub.input,
+      batch: existingSub.batch,
       source: undefined,
     };
 
@@ -122,6 +124,7 @@ export class CronSubscriptionsService {
       projectId: dto.projectId ? new Types.ObjectId(dto.projectId) : null,
       name: dto.name,
       input: dto.input ? dto.input : null,
+      batch: dto.batch ? dto.batch : null,
       cronExpression: dto.cronExpression,
       jobName: dto.jobName,
       jobParameters: dto.jobParameters,

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.controller.ts
@@ -18,11 +18,11 @@ import { Roles } from '../../../auth/decorators/roles.decorator';
 import { RolesGuard } from '../../../auth/guards/role.guard';
 import { ApiKeyStrategy } from '../../../auth/strategies/api-key.strategy';
 import { JwtStrategy } from '../../../auth/strategies/jwt.strategy';
-import { PatchSubscriptionDto } from '../subscriptions.dto';
 import {
-  DuplicateEventSubscriptionDto,
-  EventSubscriptionDto,
-} from './event-subscriptions.dto';
+  DuplicateSubscriptionDto,
+  PatchSubscriptionDto,
+} from '../subscriptions.dto';
+import { EventSubscriptionDto } from './event-subscriptions.dto';
 import { EventSubscriptionsDocument } from './event-subscriptions.model';
 import { EventSubscriptionsService } from './event-subscriptions.service';
 
@@ -33,9 +33,7 @@ export class EventSubscriptionsController {
   @UseGuards(AuthGuard([JwtStrategy.name, ApiKeyStrategy.name]), RolesGuard)
   @Roles(Role.User)
   @Post()
-  async create(
-    @Body() dto: EventSubscriptionDto | DuplicateEventSubscriptionDto,
-  ) {
+  async create(@Body() dto: EventSubscriptionDto | DuplicateSubscriptionDto) {
     if ('subscriptionId' in dto) {
       return await this.subscriptionsService.duplicate(dto.subscriptionId);
     } else {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.dto.ts
@@ -1,63 +1,18 @@
-import { Type } from 'class-transformer';
 import {
   IsArray,
-  IsBoolean,
   IsInt,
-  IsMongoId,
   IsNotEmpty,
   IsOptional,
   IsString,
   Min,
-  ValidateNested,
 } from 'class-validator';
-import { CustomJobNameExists } from '../../../../validators/custom-job-name-exists.validator';
-import { IsValidJobConditionsArray } from '../../../../validators/is-valid-job-conditions-array.validator';
-import { JobParameterDto } from '../subscriptions.dto';
-import {
-  AndJobCondition,
-  JobCondition,
-  OrJobCondition,
-} from './event-subscriptions.model';
+import { BaseSubscriptionDto } from '../subscriptions.dto';
 
-export class DuplicateEventSubscriptionDto {
-  @IsMongoId()
-  @IsNotEmpty()
-  @IsString()
-  public subscriptionId: string;
-}
-
-export class EventSubscriptionDto {
-  @IsString()
-  @IsNotEmpty()
-  public name!: string;
-
-  @IsBoolean()
-  @IsOptional()
-  public isEnabled?: boolean;
-
-  @IsMongoId()
-  @IsOptional()
-  public projectId?: string; // if projectId is not set, the subscription is for all projects
-
+export class EventSubscriptionDto extends BaseSubscriptionDto {
   @IsArray()
   @IsString({ each: true })
   @IsNotEmpty()
   public findings!: string[];
-
-  @IsString()
-  @IsNotEmpty()
-  @CustomJobNameExists()
-  public jobName!: string;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => JobParameterDto)
-  @IsOptional()
-  public jobParameters?: JobParameterDto[];
-
-  @IsValidJobConditionsArray()
-  @IsOptional()
-  public conditions?: Array<JobCondition | OrJobCondition | AndJobCondition>;
 
   @IsNotEmpty()
   @IsInt()

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/event-subscriptions/event-subscriptions.model.ts
@@ -1,27 +1,14 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { DataSource } from '../../data-source/data-source.model';
+import {
+  AndJobCondition,
+  JobCondition,
+  JobParameter,
+  OrJobCondition,
+} from '../subscriptions.type';
 
 export type EventSubscriptionsDocument = EventSubscription & Document;
-
-export class JobParameter {
-  public name!: string;
-  public value!: unknown;
-}
-
-export class JobCondition {
-  public lhs!: string | number | boolean | Array<boolean | string | number>;
-  public operator: string;
-  public rhs!: string | number | boolean | Array<boolean | string | number>;
-}
-
-export class AndJobCondition {
-  public and!: Array<AndJobCondition | OrJobCondition | JobCondition>;
-}
-
-export class OrJobCondition {
-  public or!: Array<AndJobCondition | OrJobCondition | JobCondition>;
-}
 
 @Schema()
 export class EventSubscription {
@@ -49,7 +36,7 @@ export class EventSubscription {
   @Prop()
   public cooldown: number;
 
-  // true for a built-in subsctiption, false otherwise
+  // true for a built-in subscription, false otherwise
   @Prop()
   public builtIn?: boolean;
 

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.dto.ts
@@ -1,5 +1,28 @@
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { CustomJobNameExists } from '../../../validators/custom-job-name-exists.validator';
 import { IsTypeIn } from '../../../validators/is-type-in.validator';
+import { IsValidJobConditionsArray } from '../../../validators/is-valid-job-conditions-array.validator';
+import {
+  AndJobCondition,
+  JobCondition,
+  OrJobCondition,
+} from './subscriptions.type';
+
+export class DuplicateSubscriptionDto {
+  @IsMongoId()
+  @IsNotEmpty()
+  @IsString()
+  public subscriptionId: string;
+}
 
 export class JobParameterDto {
   @IsString()
@@ -13,4 +36,33 @@ export class PatchSubscriptionDto {
   @IsBoolean()
   @IsOptional()
   isEnabled?: boolean;
+}
+
+export class BaseSubscriptionDto {
+  @IsString()
+  @IsNotEmpty()
+  public name!: string;
+
+  @IsBoolean()
+  @IsOptional()
+  public isEnabled?: boolean;
+
+  @IsMongoId()
+  @IsOptional()
+  public projectId?: string; // if projectId is not set, the subscription is for all projects
+
+  @IsString()
+  @IsNotEmpty()
+  @CustomJobNameExists()
+  public jobName!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => JobParameterDto)
+  @IsOptional()
+  public jobParameters?: JobParameterDto[];
+
+  @IsValidJobConditionsArray()
+  @IsOptional()
+  public conditions?: Array<JobCondition | OrJobCondition | AndJobCondition>;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.type.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.type.ts
@@ -6,3 +6,22 @@ export type Subscription = CronSubscription | EventSubscription;
 export type SubscriptionWithType = (CronSubscription | EventSubscription) & {
   triggerType: 'cron' | 'event';
 };
+
+export class JobParameter {
+  public name!: string;
+  public value!: unknown;
+}
+
+export class JobCondition {
+  public lhs!: string | number | boolean | Array<boolean | string | number>;
+  public operator: string;
+  public rhs!: string | number | boolean | Array<boolean | string | number>;
+}
+
+export class AndJobCondition {
+  public and!: Array<AndJobCondition | OrJobCondition | JobCondition>;
+}
+
+export class OrJobCondition {
+  public or!: Array<AndJobCondition | OrJobCondition | JobCondition>;
+}

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
@@ -15,13 +15,13 @@ import { JobContainer } from '../container/job-container.model';
 import { CustomJobsService } from '../custom-jobs/custom-jobs.service';
 import { ProjectService } from '../reporting/project.service';
 import { CronSubscription } from './cron-subscriptions/cron-subscriptions.model';
+import { EventSubscription } from './event-subscriptions/event-subscriptions.model';
 import {
   AndJobCondition,
-  EventSubscription,
   JobCondition,
   JobParameter,
   OrJobCondition,
-} from './event-subscriptions/event-subscriptions.model';
+} from './subscriptions.type';
 import { SubscriptionsUtils } from './subscriptions.utils';
 
 describe('Findings Handler Base', () => {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
@@ -847,6 +847,44 @@ describe('Findings Handler Base', () => {
       expect(sub.jobParameters[0].name).toStrictEqual(cs.jobParameters[0].name);
     });
 
+    it('Should return a CronSubscription with batching enabled', async () => {
+      // Arrange
+      const cs: CronSubscription = {
+        name: 'Yaml to parse',
+        file: 'not a file.yaml',
+        builtIn: true,
+        isEnabled: true,
+        cronExpression: '*/30 * * * * *',
+        jobName: 'HostnameResolvingJob',
+        jobParameters: [{ name: 'domainName', value: 'example.com' }],
+        conditions: [],
+        input: 'ALL_WEBSITES',
+        batch: { enabled: true, size: 100 },
+      };
+
+      let yaml = [
+        `name: ${cs.name}`,
+        `cronExpression: "${cs.cronExpression}"`,
+        `job:`,
+        `  name: ${cs.jobName}`,
+        `  parameters:`,
+        `    - name: ${cs.jobParameters[0].name}`,
+        `      value: ${cs.jobParameters[0].value}`,
+        `input: ALL_WEBSITES`,
+        `batch:`,
+        `  enabled: ${cs.batch.enabled}`,
+        `  size: ${cs.batch.size}`,
+      ].join('\n');
+
+      // Act
+      const sub = SubscriptionsUtils.parseCronSubscriptionYaml(yaml);
+
+      // Assert
+      expect(sub.input).toStrictEqual(cs.input);
+      expect(sub.batch.enabled).toStrictEqual(cs.batch.enabled);
+      expect(sub.batch.size).toStrictEqual(cs.batch.size);
+    });
+
     it('Should return an EventSubscription', async () => {
       // Arrange
       const es: EventSubscription = {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
@@ -14,7 +14,10 @@ import { Finding } from '../../findings/findings.service';
 import { ConfigService } from '../admin/config/config.service';
 import { CustomJobsService } from '../custom-jobs/custom-jobs.service';
 import { JobFactoryUtils } from '../jobs/jobs.factory';
-import { CronSubscription } from './cron-subscriptions/cron-subscriptions.model';
+import {
+  CronSubscription,
+  CronSubscriptionBatching,
+} from './cron-subscriptions/cron-subscriptions.model';
 import { EventSubscription } from './event-subscriptions/event-subscriptions.model';
 import {
   AndJobCondition,
@@ -536,6 +539,15 @@ export class SubscriptionsUtils {
       }
     }
 
+    let batch: CronSubscriptionBatching = undefined;
+
+    if (subYamlJson.batch) {
+      batch = {
+        enabled: subYamlJson.batch.enabled,
+        size: subYamlJson.batch.size ?? undefined,
+      };
+    }
+
     const sub: CronSubscription = {
       name: subYamlJson.name,
       isEnabled: true,
@@ -546,6 +558,7 @@ export class SubscriptionsUtils {
       projectId: null,
       jobParameters: params,
       conditions: conditions,
+      batch: batch,
     };
 
     return sub;

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
@@ -15,14 +15,15 @@ import { ConfigService } from '../admin/config/config.service';
 import { CustomJobsService } from '../custom-jobs/custom-jobs.service';
 import { JobFactoryUtils } from '../jobs/jobs.factory';
 import { CronSubscription } from './cron-subscriptions/cron-subscriptions.model';
+import { EventSubscription } from './event-subscriptions/event-subscriptions.model';
 import {
   AndJobCondition,
-  EventSubscription,
   JobCondition,
   JobParameter,
   OrJobCondition,
-} from './event-subscriptions/event-subscriptions.model';
-import { Subscription, SubscriptionWithType } from './subscriptions.type';
+  Subscription,
+  SubscriptionWithType,
+} from './subscriptions.type';
 
 type FsPromisesApi = MemfsFsPromisesApi | typeof realFs.promises;
 

--- a/packages/backend/jobs-manager/service/src/modules/findings/commands/findings-handler-base.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/commands/findings-handler-base.ts
@@ -5,12 +5,12 @@ import { CustomJobsService } from '../../database/custom-jobs/custom-jobs.servic
 import { JobExecutionsService } from '../../database/jobs/job-executions.service';
 import { JobFactory } from '../../database/jobs/jobs.factory';
 import { Job } from '../../database/jobs/models/jobs.model';
-import { JobParameter } from '../../database/subscriptions/event-subscriptions/event-subscriptions.model';
 import { EventSubscriptionsService } from '../../database/subscriptions/event-subscriptions/event-subscriptions.service';
 import { SubscriptionsUtils } from '../../database/subscriptions/subscriptions.utils';
 
 import { SecretsService } from '../../database/secrets/secrets.service';
 import { SubscriptionTriggersService } from '../../database/subscriptions/subscription-triggers/subscription-triggers.service';
+import { JobParameter } from '../../database/subscriptions/subscriptions.type';
 import { FindingCommand } from './findings.command';
 
 export abstract class FindingHandlerBase<T extends FindingCommand>

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.service.ts
@@ -27,10 +27,15 @@ import { FindingsFilter } from './findings-filter.type';
 export type Finding =
   | HostnameIpFinding
   | HostnameFinding
+  | HostnameBatchFinding
   | IpFinding
+  | IpBatchFinding
   | IpRangeFinding
+  | IpRangeBatchFinding
   | PortFinding
+  | PortBatchFinding
   | WebsiteFinding
+  | WebsiteBatchFinding
   | JobStatusFinding
   | CreateCustomFinding
   | TagFinding;
@@ -56,6 +61,21 @@ export class PortFinding extends FindingBase {
   ];
 }
 
+export class PortBatchFinding extends FindingBase {
+  type: 'PortBatchFinding';
+  key: 'PortBatchFinding';
+  ipBatch: string[];
+  portBatch: number[];
+  protocolBatch: ('tcp' | 'udp')[];
+
+  constructor() {
+    super();
+    this.ipBatch = [];
+    this.portBatch = [];
+    this.protocolBatch = [];
+  }
+}
+
 export class ResourceFinding extends FindingBase {
   domainName?: string;
   ip?: string;
@@ -70,6 +90,27 @@ export class WebsiteFinding extends ResourceFinding {
   path: string = '/';
   ssl?: boolean;
   protocol: 'tcp' = 'tcp';
+}
+
+export class WebsiteBatchFinding extends FindingBase {
+  type: 'WebsiteBatchFinding';
+  key: 'WebsiteBatchFinding';
+  sslBatch: boolean[];
+  pathBatch: string[];
+  ipBatch: string[];
+  protocolBatch: 'tcp'[];
+  portBatch: number[];
+  domainBatch: string[];
+
+  constructor() {
+    super();
+    this.domainBatch = [];
+    this.ipBatch = [];
+    this.portBatch = [];
+    this.protocolBatch = [];
+    this.pathBatch = [];
+    this.sslBatch = [];
+  }
 }
 
 export class CreateCustomFinding extends ResourceFinding {
@@ -97,11 +138,35 @@ export class HostnameFinding extends FindingBase {
   domainName: string;
 }
 
+export class HostnameBatchFinding extends FindingBase {
+  type: 'HostnameBatchFinding';
+  key: 'HostnameBatchFinding';
+  projectId: string;
+  domainBatch: string[];
+
+  constructor() {
+    super();
+    this.domainBatch = [];
+  }
+}
+
 export class IpFinding extends FindingBase {
   type: 'IpFinding';
   key: 'IpFinding';
   projectId: string;
   ip: string;
+}
+
+export class IpBatchFinding extends FindingBase {
+  type: 'IpBatchFinding';
+  key: 'IpBatchFinding';
+  projectId: string;
+  ipBatch: string[];
+
+  constructor() {
+    super();
+    this.ipBatch = [];
+  }
 }
 
 export class IpRangeFinding extends FindingBase {
@@ -110,6 +175,20 @@ export class IpRangeFinding extends FindingBase {
   projectId: string;
   ip: string;
   mask: number; // ex: 24
+}
+
+export class IpRangeBatchFinding extends FindingBase {
+  type: 'IpRangeBatchFinding';
+  key: 'IpRangeBatchFinding';
+  projectId: string;
+  ipBatch: string[];
+  maskBatch: number[]; // ex: 24
+
+  constructor() {
+    super();
+    this.ipBatch = [];
+    this.maskBatch = [];
+  }
 }
 
 export class HostnameIpFinding extends FindingBase {

--- a/packages/backend/jobs-manager/service/src/types/job-definition.type.ts
+++ b/packages/backend/jobs-manager/service/src/types/job-definition.type.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'mongoose';
 import { Job } from '../modules/database/jobs/models/jobs.model';
-import { JobParameter } from '../modules/database/subscriptions/event-subscriptions/event-subscriptions.model';
+import { JobParameter } from '../modules/database/subscriptions/subscriptions.type';
 import { JobParameterDefinition } from './job-parameter-definition.type';
 
 export interface JobDefinition {

--- a/packages/backend/jobs-manager/service/src/validators/depends-on.validator.ts
+++ b/packages/backend/jobs-manager/service/src/validators/depends-on.validator.ts
@@ -1,0 +1,26 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+export function DependsOn(
+  propertyName: string,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: Object, variableName: string) {
+    registerDecorator({
+      name: 'dependsOn',
+      target: object.constructor,
+      propertyName: variableName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const property = args.object[propertyName];
+          if (property === undefined || property == null) return false;
+          return true;
+        },
+      },
+    });
+  };
+}

--- a/packages/backend/jobs-manager/service/src/validators/is-valid-job-conditions-array.validator.spec.ts
+++ b/packages/backend/jobs-manager/service/src/validators/is-valid-job-conditions-array.validator.spec.ts
@@ -5,7 +5,7 @@ import {
   AndJobCondition,
   JobCondition,
   OrJobCondition,
-} from '../modules/database/subscriptions/event-subscriptions/event-subscriptions.model';
+} from '../modules/database/subscriptions/subscriptions.type';
 import { isValidJobConditionsArray } from './is-valid-job-conditions-array.validator';
 
 const validConditions: Array<

--- a/packages/frontend/stalker-app/src/app/api/jobs/subscriptions/cron-subscriptions.service.ts
+++ b/packages/frontend/stalker-app/src/app/api/jobs/subscriptions/cron-subscriptions.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom, map, Observable } from 'rxjs';
-import { CronSubscription, CronSubscriptionData } from '../../../shared/types/subscriptions/subscription.type';
 import { environment } from '../../../../environments/environment';
+import { CronSubscription, CronSubscriptionData } from '../../../shared/types/subscriptions/subscription.type';
 import { allProjectsSubscriptions } from '../../constants';
 import { GenericSubscriptionService } from './base-subscription.service';
 
@@ -44,6 +44,7 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       cronExpression: newSub.cronExpression,
       projectId: newSub.projectId ? newSub.projectId : allProjectsSubscriptions,
       input: newSub.input ?? undefined,
+      batch: newSub.batch ?? undefined,
       job: {
         name: newSub.jobName,
       },
@@ -82,6 +83,10 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       data['input'] = subscription.input;
     }
 
+    if (subscription.input) {
+      data['batch'] = subscription.batch;
+    }
+
     if (subscription.conditions) {
       data['conditions'] = subscription.conditions;
     }
@@ -101,6 +106,7 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       name: data.name,
       cronExpression: data.cronExpression,
       input: data.input ?? undefined,
+      batch: data.batch ?? undefined,
       projectId: data.projectId ? data.projectId : allProjectsSubscriptions,
       job: { name: data.jobName },
       builtIn: data.builtIn,

--- a/packages/frontend/stalker-app/src/app/modules/jobs/subscriptions/subscription.component.ts
+++ b/packages/frontend/stalker-app/src/app/modules/jobs/subscriptions/subscription.component.ts
@@ -33,25 +33,24 @@ import {
   switchMap,
   timer,
 } from 'rxjs';
+import { parse } from 'yaml';
+import { allProjectsSubscriptions } from '../../../api/constants';
+import { cronSubscriptionKey } from '../../../api/jobs/subscriptions/cron-subscriptions.service';
 import { eventSubscriptionKey } from '../../../api/jobs/subscriptions/event-subscriptions.service';
 import { SubscriptionService, SubscriptionType } from '../../../api/jobs/subscriptions/subscriptions.service';
+import { ProjectsService } from '../../../api/projects/projects.service';
 import { ThemeService } from '../../../services/theme.service';
 import { AppHeaderComponent } from '../../../shared/components/page-header/page-header.component';
 import { PanelSectionModule } from '../../../shared/components/panel-section/panel-section.module';
 import { HasUnsavedChanges } from '../../../shared/guards/unsaved-changes-can-deactivate.component';
 import { SharedModule } from '../../../shared/shared.module';
-import { Subscription } from '../../../shared/types/subscriptions/subscription.type';
-import { DisabledPillTagComponent } from '../../../shared/widget/pill-tag/disabled-pill-tag.component';
-import { SavingButtonComponent } from '../../../shared/widget/spinner-button/saving-button.component';
-import { SpinnerButtonComponent } from '../../../shared/widget/spinner-button/spinner-button.component';
-import { TextMenuComponent } from '../../../shared/widget/text-menu/text-menu.component';
-import { parse } from 'yaml';
-import { allProjectsSubscriptions } from '../../../api/constants';
-import { cronSubscriptionKey } from '../../../api/jobs/subscriptions/cron-subscriptions.service';
-import { ProjectsService } from '../../../api/projects/projects.service';
 import { DataSource } from '../../../shared/types/data-source/data-source.type';
 import { ProjectSummary } from '../../../shared/types/project/project.summary';
+import { Subscription } from '../../../shared/types/subscriptions/subscription.type';
 import { CodeEditorComponent, CodeEditorTheme } from '../../../shared/widget/code-editor/code-editor.component';
+import { DisabledPillTagComponent } from '../../../shared/widget/pill-tag/disabled-pill-tag.component';
+import { SavingButtonComponent } from '../../../shared/widget/spinner-button/saving-button.component';
+import { TextMenuComponent } from '../../../shared/widget/text-menu/text-menu.component';
 import { DataSourceComponent } from '../../data-source/data-source/data-source.component';
 import { SubscriptionInteractionService } from './subscription-interaction.service';
 import { cronSubscriptionTemplate, eventSubscriptionTemplate } from './subscription-templates';
@@ -92,7 +91,6 @@ import { cronSubscriptionTemplate, eventSubscriptionTemplate } from './subscript
     MatTabsModule,
     MatTooltipModule,
     MatCardModule,
-    SpinnerButtonComponent,
     TextMenuComponent,
     PanelSectionModule,
     MatDividerModule,

--- a/packages/frontend/stalker-app/src/app/shared/types/subscriptions/subscription.type.ts
+++ b/packages/frontend/stalker-app/src/app/shared/types/subscriptions/subscription.type.ts
@@ -19,10 +19,16 @@ export interface EventSubscriptionData extends SubscriptionData {
   findings: string[];
 }
 
+export interface CronSubscriptionBatching {
+  enabled: boolean;
+  size?: number;
+}
+
 export interface CronSubscriptionData extends SubscriptionData {
   type: 'cron';
   cronExpression: string;
-  input?: 'ALL_DOMAINS' | 'ALL_HOSTS' | 'ALL_TCP_PORTS';
+  input?: 'ALL_DOMAINS' | 'ALL_HOSTS' | 'ALL_TCP_PORTS' | 'ALL_IP_RANGES' | 'ALL_WEBSITES';
+  batch?: CronSubscriptionBatching;
 }
 
 export interface SubscriptionData {


### PR DESCRIPTION
Implementing the batching of data in the cron susbcriptions. It will allow a cron subscription to be started with, for instance, an array of 100 domain names instead of the current string of one domain name.

Here is an example of the batching syntax in a real subscription from the templates' repository:

```yaml
name: Refreshing all domain names
input: ALL_DOMAINS
batch:
  enabled: true
  size: 100
triggerType: cron
cronExpression: "0 0 */7 * *"
job:
  name: DomainNameResolvingJob
  parameters:
    - name: domainNames
      value: ${domainBatch}

```

This subscription will start a `DomainNameResolvingJob` by giving an array of up to 100 domain names in the `domainNames` parameter.


TODO:

- [x] Updating the documentation to reflect the new batching system