### PR TITLE
Feature/cron subscription cooldown

### DIFF
--- a/docs/docs/advanced/correlation_keys.md
+++ b/docs/docs/advanced/correlation_keys.md
@@ -13,10 +13,13 @@ Examples of correlation keys for a project with the identifier `65f123fc861a16c1
 | Port     | `project:65f123fc861a16c1a9698357;host:127.0.0.1;port:22;protocol:tcp`                             |
 | Website  | `project:65f123fc861a16c1a9698357;host:206.189.173.197;port:80;protocol:tcp;domain:a1b2.ca;path:/` |
 
-A correlation key also exists for a different concept that is not really a resource per say. This concept is the `IP ranges`. IP ranges are stored on the project itself, and they represent an IPv4 subnet range.
+A correlation key also exists for other concepts that are not considered resources per say.
 
-A correlation key for an IP range would look like the following, where mask is a value between 0 and 32, inclusively:
+The first concept is the `project`. A correlation key can created for a project, and it is used to mark cron subscription triggers. A project correlation key only has the project part of the other correlation keys. 
+
+The second concept is the `IP ranges`. IP ranges are stored on the project itself, and they represent an IPv4 subnet range. An IP range correlation key has two main parts, the initial IP under host, and the mask, a value between 0 and 32, inclusively.
 
 | Entity   | Correlation key example                                   |
 | -------- | --------------------------------------------------------- |
+| Project  | `project:65f123fc861a16c1a9698357`                        |
 | Ip range | `project:65f123fc861a16c1a9698357;host:127.0.0.1;mask:32` |

--- a/docs/docs/concepts/subscriptions.md
+++ b/docs/docs/concepts/subscriptions.md
@@ -57,7 +57,7 @@ A cron subscription contains the following main elements :
     a list.
 - The optional `batch` element is an object containing two other values:
   - `enabled`: `true` or `false`, enabling or disabling the batching of data
-  - `size`: an optional number greater than 0, which represents the maximum size of input arrays when batching
+  - `size`: an optional number greater than 0, which represents the maximum size of input arrays when batching. When size is not specified, all the resources are used.
 - The optional `cooldown` element is the time in seconds between two successful calls to the job. It is evaluated after the `cronExpression` and ensures that a job is only started for a project if the cooldown period is done.
 
 #### Cron Subscription Simple Example

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/correlation.utils.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/correlation.utils.ts
@@ -64,6 +64,7 @@ export class CorrelationKeyUtils {
   /**
    * Valid combinations are:
    *
+   * - project correlation key: requires only the projectId
    * - domain correlation key: [domainName]
    * - host correlation key: [ip]
    * - ip range correlation key: [ip,mask]
@@ -93,6 +94,10 @@ export class CorrelationKeyUtils {
       throw new HttpBadRequestException(
         'ProjectId is required in order to create a correlation key.',
       );
+    }
+
+    if (!domainName && !ip && !port && !protocol && !mask && !path) {
+      return CorrelationKeyUtils.projectCorrelationKey(projectId);
     }
 
     if (path && !domainName) {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
@@ -44,5 +44,5 @@ export class CronSubscriptionDto extends BaseSubscriptionDto {
   @IsOptional()
   @IsInt()
   @Min(0)
-  public cooldown: number;
+  public cooldown?: number;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.dto.ts
@@ -2,6 +2,7 @@ import { Type } from 'class-transformer';
 import {
   IsBoolean,
   IsIn,
+  IsInt,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -39,4 +40,9 @@ export class CronSubscriptionDto extends BaseSubscriptionDto {
   @IsOptional()
   @Type(() => CronSubscriptionBatchingDto)
   public batch?: CronSubscriptionBatchingDto;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  public cooldown: number;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.model.ts
@@ -66,6 +66,9 @@ export class CronSubscription {
 
   @Prop()
   public source?: DataSource;
+
+  @Prop()
+  public cooldown?: number;
 }
 
 export const CronSubscriptionsSchema =

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.module.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.module.ts
@@ -10,6 +10,7 @@ import { PortModule } from '../../reporting/port/port.module';
 import { ProjectModule } from '../../reporting/project.module';
 import { WebsiteModule } from '../../reporting/websites/website.module';
 import { SecretsModule } from '../../secrets/secrets.module';
+import { SubscriptionTriggersModule } from '../subscription-triggers/subscription-triggers.module';
 import { CronSubscriptionsController } from './cron-subscriptions.controller';
 import { CronSubscriptionsService } from './cron-subscriptions.service';
 
@@ -26,6 +27,7 @@ import { CronSubscriptionsService } from './cron-subscriptions.service';
     SecretsModule,
     CustomJobsModule,
     WebsiteModule,
+    SubscriptionTriggersModule,
   ],
   controllers: [CronSubscriptionsController],
   providers: [CronSubscriptionsService, CustomJobNameExistsRule],

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.service.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.service.ts
@@ -196,10 +196,13 @@ export class CronSubscriptionsService {
 
     if (!sub.jobParameters) return;
 
-    await this.setupSubscriptionsForProjects(sub);
+    await this.setupSubscriptionsForProjects(sub, sub._id.toString());
   }
 
-  private async setupSubscriptionsForProjects(sub: CronSubscriptionsDocument) {
+  private async setupSubscriptionsForProjects(
+    sub: CronSubscription,
+    subId: string,
+  ) {
     // if no project id, it launches for all projects
     const projectIds = sub.projectId
       ? [sub.projectId.toString()]
@@ -210,7 +213,7 @@ export class CronSubscriptionsService {
       if (
         sub.cooldown &&
         !(await this.subscriptionTriggerService.attemptTrigger(
-          sub._id.toString(),
+          subId,
           CorrelationKeyUtils.generateCorrelationKey(projectId),
           sub.cooldown,
           null,

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/cron-subscriptions/cron-subscriptions.spec.ts
@@ -1709,6 +1709,7 @@ describe('Cron Subscriptions Service', () => {
       //@ts-expect-error
       await subscriptionsService.setupSubscriptionsForProjects(
         <CronSubscription>ipRangeScanCronSub,
+        '',
       );
 
       // Assert

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.spec.ts
@@ -860,6 +860,7 @@ describe('Findings Handler Base', () => {
         conditions: [],
         input: 'ALL_WEBSITES',
         batch: { enabled: true, size: 100 },
+        cooldown: 123456,
       };
 
       let yaml = [
@@ -871,6 +872,7 @@ describe('Findings Handler Base', () => {
         `    - name: ${cs.jobParameters[0].name}`,
         `      value: ${cs.jobParameters[0].value}`,
         `input: ALL_WEBSITES`,
+        `cooldown: ${cs.cooldown}`,
         `batch:`,
         `  enabled: ${cs.batch.enabled}`,
         `  size: ${cs.batch.size}`,
@@ -883,6 +885,7 @@ describe('Findings Handler Base', () => {
       expect(sub.input).toStrictEqual(cs.input);
       expect(sub.batch.enabled).toStrictEqual(cs.batch.enabled);
       expect(sub.batch.size).toStrictEqual(cs.batch.size);
+      expect(sub.cooldown).toStrictEqual(cs.cooldown);
     });
 
     it('Should return an EventSubscription', async () => {

--- a/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/subscriptions/subscriptions.utils.ts
@@ -558,6 +558,7 @@ export class SubscriptionsUtils {
       projectId: null,
       jobParameters: params,
       conditions: conditions,
+      cooldown: subYamlJson.cooldown ?? undefined,
       batch: batch,
     };
 

--- a/packages/backend/jobs-manager/service/src/modules/findings/findings.service.spec.ts
+++ b/packages/backend/jobs-manager/service/src/modules/findings/findings.service.spec.ts
@@ -125,7 +125,7 @@ describe('Findings Service Spec', () => {
   });
 
   it.each([
-    [undefined, undefined, undefined],
+    ['example.org', '2.2.2.2', undefined],
     ['example.org', undefined, 80],
     ['example.org', '1.1.1.1', undefined],
     [undefined, undefined, 1],

--- a/packages/frontend/stalker-app/src/app/api/jobs/subscriptions/cron-subscriptions.service.ts
+++ b/packages/frontend/stalker-app/src/app/api/jobs/subscriptions/cron-subscriptions.service.ts
@@ -42,6 +42,7 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       builtIn: false,
       name: newSub.name,
       cronExpression: newSub.cronExpression,
+      cooldown: newSub.cooldown ?? undefined,
       projectId: newSub.projectId ? newSub.projectId : allProjectsSubscriptions,
       input: newSub.input ?? undefined,
       batch: newSub.batch ?? undefined,
@@ -87,6 +88,10 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       data['batch'] = subscription.batch;
     }
 
+    if (subscription.cooldown) {
+      data['cooldown'] = subscription.cooldown;
+    }
+
     if (subscription.conditions) {
       data['conditions'] = subscription.conditions;
     }
@@ -105,6 +110,7 @@ export class CronSubscriptionsService implements GenericSubscriptionService<Cron
       isEnabled: data.isEnabled,
       name: data.name,
       cronExpression: data.cronExpression,
+      cooldown: data.cooldown ?? undefined,
       input: data.input ?? undefined,
       batch: data.batch ?? undefined,
       projectId: data.projectId ? data.projectId : allProjectsSubscriptions,

--- a/packages/frontend/stalker-app/src/app/shared/types/subscriptions/subscription.type.ts
+++ b/packages/frontend/stalker-app/src/app/shared/types/subscriptions/subscription.type.ts
@@ -29,6 +29,7 @@ export interface CronSubscriptionData extends SubscriptionData {
   cronExpression: string;
   input?: 'ALL_DOMAINS' | 'ALL_HOSTS' | 'ALL_TCP_PORTS' | 'ALL_IP_RANGES' | 'ALL_WEBSITES';
   batch?: CronSubscriptionBatching;
+  cooldown?: number;
 }
 
 export interface SubscriptionData {


### PR DESCRIPTION
This pull request adds the concept of cooldown to the cron subscriptions, allowing a user to try to start a job often with a quick cron expression, but only really start it as often as the cooldown allows. It is the same mechanic used in event subscriptions, but the triggers are done at the project level. 

Therefore, a cooldown limits how often a cron subscription will start a job for a project.