### PR TITLE
Making community coherent with enterprise

### DIFF
--- a/packages/frontend/stalker-app/src/app/modules/tables/resources-config.ts
+++ b/packages/frontend/stalker-app/src/app/modules/tables/resources-config.ts
@@ -5,8 +5,8 @@ interface ResourceTableConfig {
 }
 
 export const resourcesTableConfig: Record<ResourceType, ResourceTableConfig> = {
-  domains: { baseColumns: ['domainName', 'project'] },
-  hosts: { baseColumns: ['hostIp', 'project'] },
-  ports: { baseColumns: ['port', 'portHost', 'project'] },
-  websites: { baseColumns: ['websiteUrl', 'project'] },
+  domain: { baseColumns: ['domainName', 'project'] },
+  host: { baseColumns: ['hostIp', 'project'] },
+  port: { baseColumns: ['port', 'portHost', 'project'] },
+  website: { baseColumns: ['websiteUrl', 'project'] },
 };

--- a/packages/frontend/stalker-app/src/app/services/resources/resources-service.factory.ts
+++ b/packages/frontend/stalker-app/src/app/services/resources/resources-service.factory.ts
@@ -17,16 +17,16 @@ export class ResourcesServiceFactory {
 
   public create(resource: ResourceType): ResourceService<Resource> {
     switch (resource) {
-      case 'domains':
+      case 'domain':
         return this.domainsService;
 
-      case 'hosts':
+      case 'host':
         return this.hostsService;
 
-      case 'ports':
+      case 'port':
         return this.portsService;
 
-      case 'websites':
+      case 'website':
         return this.websitesService;
 
       default:

--- a/packages/frontend/stalker-app/src/app/shared/types/resources.type.ts
+++ b/packages/frontend/stalker-app/src/app/shared/types/resources.type.ts
@@ -1,6 +1,6 @@
 import { IdentifiedElement } from './identified-element.type';
 
-export type ResourceType = 'domains' | 'hosts' | 'ports' | 'websites';
+export type ResourceType = 'domain' | 'host' | 'port' | 'website';
 
 export type Resource = IdentifiedElement & {
   correlationKey: string;


### PR DESCRIPTION
The 'same' PR from enterprise that standardizes the 'domain', 'host', etc resource type