### PR TITLE
Fix for the frontend of job executions

### DIFF
--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.controller.ts
@@ -36,7 +36,12 @@ import { CustomJobsService } from '../custom-jobs/custom-jobs.service';
 import { SecretsService } from '../secrets/secrets.service';
 import { JobParameter } from '../subscriptions/subscriptions.type';
 import { JobExecutionsService } from './job-executions.service';
-import { JobExecutionsDto, JobManagementDto, StartJobDto } from './jobs.dto';
+import {
+  JobExecutionsDto,
+  JobManagementDto,
+  StartedJobDto,
+  StartJobDto,
+} from './jobs.dto';
 import { JobFactory, JobFactoryUtils } from './jobs.factory';
 import { Job, JobDocument } from './models/jobs.model';
 
@@ -55,14 +60,14 @@ export class JobsController {
    * @remarks
    * Get the latest job executions.
    */
-  @ApiDefaultResponsePage(Job)
+  @ApiDefaultResponsePage(StartedJobDto)
   @UseGuards(AuthGuard([JwtStrategy.name, ApiKeyStrategy.name]), ScopesGuard)
   @Scopes('automation:job-executions:read')
   @Get()
   async getAllJobs(
     @Query()
     dto: JobExecutionsDto,
-  ): Promise<Page<JobDocument>> {
+  ): Promise<Page<StartedJobDto>> {
     return await this.jobsService.getAll(dto);
   }
 

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.dto.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/jobs.dto.ts
@@ -1,4 +1,4 @@
-import { IntersectionType } from '@nestjs/swagger';
+import { IntersectionType, OmitType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
@@ -13,6 +13,7 @@ import { PagingDto } from '../database.dto';
 import { FilterByProjectDto } from '../reporting/resource.dto';
 import { JobParameterDto } from '../subscriptions/subscriptions.dto';
 import { JobParameter } from '../subscriptions/subscriptions.type';
+import { Job } from './models/jobs.model';
 
 export class JobExecutionsDto extends IntersectionType(
   PagingDto,
@@ -49,4 +50,11 @@ export class JobManagementDto {
   @IsNotEmpty()
   @IsIn(jobManagementTasks)
   task: JobManagementTask;
+}
+
+export class StartedJobDto extends OmitType(Job, ['output'] as const) {
+  _id: string;
+  numberOfErrors: number;
+  numberOfWarnings: number;
+  numberOfFindings: number;
 }

--- a/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/jobs/models/jobs.model.ts
@@ -33,10 +33,6 @@ export class Job {
   public output: TimestampedString[];
 
   @ApiProperty()
-  @Prop()
-  public publishTime: number;
-
-  @ApiProperty()
   @Prop({ index: -1 })
   public startTime: number;
 
@@ -45,7 +41,7 @@ export class Job {
   public endTime: number;
 
   @ApiProperty()
-  @Prop()
+  @Prop({ index: -1 })
   public createdAt: number;
 }
 

--- a/packages/backend/jobs-manager/service/src/modules/database/reporting/project.controller.ts
+++ b/packages/backend/jobs-manager/service/src/modules/database/reporting/project.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Param,
   Post,
   Put,
@@ -37,6 +38,8 @@ export class ProjectController {
     private readonly customJobsService: CustomJobsService,
     private readonly configService: ConfigService,
   ) {}
+
+  private logger = new Logger(ProjectController.name);
 
   /**
    * Read all projects.
@@ -86,6 +89,9 @@ export class ProjectController {
       return await this.projectService.addProject(dto);
     } catch (err) {
       if (err.code === MONGO_DUPLICATE_ERROR) {
+        this.logger.log(
+          `Conflict when creating the project ${dto.name}: ${err}`,
+        );
         // Duplicate key error
         throw new HttpConflictException();
       }

--- a/packages/frontend/stalker-app/src/app/shared/types/jobs/job.type.ts
+++ b/packages/frontend/stalker-app/src/app/shared/types/jobs/job.type.ts
@@ -29,6 +29,12 @@ export interface StartedJob extends JobInput {
   output: JobOutputResponse[];
 }
 
+export interface StartedJobOutputMetadata extends StartedJob {
+  numberOfErrors: number;
+  numberOfWarnings: number;
+  numberOfFindings: number;
+}
+
 export type StartedJobState = 'in-progress' | 'done' | 'errored';
 
 export interface StartedJobViewModel {


### PR DESCRIPTION
Fixing the frontend by counting warning and errors in the backend, removing publishTime as it is the same as createdAt